### PR TITLE
feat: support non-strapi-users

### DIFF
--- a/@types/services.d.ts
+++ b/@types/services.d.ts
@@ -25,13 +25,13 @@ export interface IServiceAdmin {
 
 export interface IServiceClient {
   kinds(): Promise<Array<AnyEntity>>;
-  list(kind?: string, uid?: UID.ContentType, user?: StrapiUser, documentId?: Data.DocumentID, locale?: string): Promise<Array<AnyEntity>>;
-  listPerUser(user: StrapiUser, kind?: string, populate?: StrapiQueryParamsParsed): Promise<Array<AnyEntity>>;
-  create(kind: string, uid: UID.ContentType, user?: StrapiUser, documentId?: Data.DocumentID, locale?: string): Promise<AnyEntity>;
-  delete(kind: string, uid: UID.ContentType, user?: StrapiUser, documentId?: Data.DocumentID, locale?: string): Promise<boolean>;
-  toggle(kind: string, uid: UID.ContentType, user?: StrapiUser, documentId?: Data.DocumentID, locale?: string): Promise<AnyEntity | boolean>;
+  list(kind?: string, uid?: UID.ContentType, user?: StrapiUser, documentId?: Data.DocumentID, locale?: string, authorId?: string): Promise<Array<AnyEntity>>;
+  listPerUser(user: StrapiUser, userId: string, kind?: string, populate?: StrapiQueryParamsParsed): Promise<Array<AnyEntity>>;
+  create(kind: string, uid: UID.ContentType, user?: StrapiUser, documentId?: Data.DocumentID, locale?: string, authorId?: string): Promise<AnyEntity>;
+  delete(kind: string, uid: UID.ContentType, user?: StrapiUser, documentId?: Data.DocumentID, locale?: string, authorId?: string): Promise<boolean>;
+  toggle(kind: string, uid: UID.ContentType, user?: StrapiUser, documentId?: Data.DocumentID, locale?: string, authorId?: string): Promise<AnyEntity | boolean>;
   prefetchConditions(props: PrefetchConditionsProps): Promise<[AnyEntity, AnyEntity]>;
-  directCreate(uid: UID.ContentType, kind: AnyEntity, related: AnyEntity, user?: StrapiUser, locale?: string): Promise<AnyEntity>;
+  directCreate(uid: UID.ContentType, kind: AnyEntity, related: AnyEntity, user?: StrapiUser, locale?: string, authorId?: string): Promise<AnyEntity>;
   directDelete(reactions: Array<CTReaction>, locale?: string): Promise<boolean>;
 }
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ For any role different than **Super Admin**, to access the **Reactions settings*
     "username": "Joe Doe",
     "email": "jdoe@sample.com",
   },
+  "userId": "32", // Custom User ID provided if X-Reactions-Author header passed
   "createdAt": "2023-09-14T20:13:01.649Z",
   "updatedAt": "2023-09-14T20:13:01.670Z",
 }
@@ -260,7 +261,8 @@ _GraphQL equivalent: [Public GraphQL API -> List all reactions associated with C
 
 Return all reactions associated with provided Collection / Single Type UID and Content Type Document ID with following combinations:
 - all - if you're not providing the user context via `Authorization` header
-- all related with user - if call is done with user context via `Authorization` header
+- all related with Strapi user - if call is done with user context via `Authorization` header
+- all related with non-Strapi user - if call is done with user ID via `X-Reactions-Author` header
 
 **Example URL**: `https://localhost:1337/api/reactions/list/single/api::homepage.homepage?locale=en`
 **Example URL**: `https://localhost:1337/api/reactions/list/collection/api::post.post/njx99iv4p4txuqp307ye8625?locale=en`
@@ -278,11 +280,12 @@ Return all reactions associated with provided Collection / Single Type UID and C
       "slug": "like",
       "name": "Like"
     },
-    "user":{ // Added if no user context provided to identify who made such reaction
+    "user":{ // Added if Strapi user context provided to identify who made such reaction
       "documentId": "njx99iv4p4txuqp307ye8625",
       "username": "mziarko+1@virtuslab.com",
       "email": "mziarko+1@virtuslab.com"
-    }
+    },
+    "userId": 17 // Added if non-Strapi user context provided to identify who made such reaction
   },
   // ...
 ]
@@ -297,7 +300,8 @@ _GraphQL equivalent: [Public GraphQL API -> List all reactions associated with p
 
 Return all reactions associated with provided user:
 - for logged in user - if call is done with user context via `Authorization` header
-- for specific ID - if you're not providing the user context via `Authorization` header
+- for specific Strapi user ID - if you're not providing the user context via `Authorization` header and you're providing the user context via `user-id` url param
+- for specific non-Strapi user ID - if you're not providing the user context via `Authorization` header and you're providing the user context via `X-Reactions-Author` header
 
 **Example URL**: `https://localhost:1337/api/reactions/list/user`
 **Example URL**: `https://localhost:1337/api/reactions/list/user/1`
@@ -334,7 +338,8 @@ _GraphQL equivalent: [Public GraphQL API -> List all reactions of kind / type as
 
 Return all reactions of specific kind / type associated with provided Collection / Single Type UID and Content Type Document ID with following combinations:
 - all - if you're not providing the user context via `Authorization` header
-- all related with user - if call is done with user context via `Authorization` header
+- all related with Strapi user - if call is done with user context via `Authorization` header
+- all related with non-Strapi user - if call is done with user ID via `X-Reactions-Author` header
 
 **Example URL**: `https://localhost:1337/api/reactions/list/like/single/api::homepage.homepage?locale=en`
 **Example URL**: `https://localhost:1337/api/reactions/list/like/collection/api::post.post/njx99iv4p4txuqp307ye8625?locale=en`
@@ -347,12 +352,13 @@ Return all reactions of specific kind / type associated with provided Collection
     "documentId": "njx99iv4p4txuqp307ye8625",
     "createdAt": "2023-09-14T20:13:01.649Z",
     "updatedAt": "2023-09-14T20:13:01.670Z",
-    "user":{ // Added if no user context provided to identify who made such reaction
+    "user":{ // Added if Strapi user context provided to identify who made such reaction
       "documentId": "njx99iv4p4txuqp307ye8625",
       "username": "mziarko+1@virtuslab.com",
       "email": "mziarko+1@virtuslab.com"
     }
   },
+  "userId": 17 // Added if non-Strapi user context provided to identify who made such reaction
   // ...
 ]
 ```
@@ -366,7 +372,8 @@ _GraphQL equivalent: [Public GraphQL API -> List all reactions of kind associate
 
 Return all reactions of specific kind associated with provided user:
 - for logged in user - if call is done with user context via `Authorization` header
-- for specific ID - if you're not providing the user context via `Authorization` header
+- for specific Strapi user ID - if you're not providing the user context via `Authorization` header and you're providing the user context via `user-id` url param
+- for specific non-Strapi user ID - if you're not providing the user context via `Authorization` header and you're providing the user context via `X-Reactions-Author` header
 
 **Example URL**: `https://localhost:1337/api/reactions/list/like/user`
 **Example URL**: `https://localhost:1337/api/reactions/list/like/user/1`
@@ -403,7 +410,10 @@ _GraphQL equivalent: [Public GraphQL API -> Set reaction for Content Type](#set-
 
 Create reaction of specific kind / type associated with provided Collection / Single Type UID and Content Type Document ID.
 
-`Authorization` header is required
+To identify the reaction author, you must provide **one** of the following headers:
+
+- `Authorization` – use this header if you want to set a reaction for a Strapi user.
+- `X-Reactions-Author` – use this header if you want to set a reaction for a non-Strapi user. The value can be any identifier that uniquely distinguishes the reaction author in your system.
 
 **Example URL**: `https://localhost:1337/api/reactions/set/like/single/api::homepage.homepage?locale=en`
 **Example URL**: `https://localhost:1337/api/reactions/set/like/collection/api::post.post/njx99iv4p4txuqp307ye8625?locale=en`
@@ -428,7 +438,10 @@ _GraphQL equivalent: [Public GraphQL API -> Unset reaction for Content Type](#un
 
 Delete reaction of specific kind / type associated with provided Collection / Single Type UID and Content Type Document ID.
 
-`Authorization` header is required
+To identify the reaction author, you must provide **one** of the following headers:
+
+- `Authorization` – use this header if you want to set a reaction for a Strapi user.
+- `X-Reactions-Author` – use this header if you want to set a reaction for a non-Strapi user. The value can be any identifier that uniquely distinguishes the reaction author in your system.
 
 **Example URL**: `https://localhost:1337/api/reactions/unset/like/single/api::homepage.homepage?locale=en`
 **Example URL**: `https://localhost:1337/api/reactions/unset/like/collection/api::post.post/njx99iv4p4txuqp307ye8625?locale=en`
@@ -448,7 +461,10 @@ _GraphQL equivalent: [Public GraphQL API -> Toggle reaction for Content Type](#t
 
 Toggle reaction of specific kind / type associated with provided Collection / Single Type UID and Content Type Document ID.
 
-`Authorization` header is required
+To identify the reaction author, you must provide **one** of the following headers:
+
+- `Authorization` – use this header if you want to set a reaction for a Strapi user.
+- `X-Reactions-Author` – use this header if you want to set a reaction for a non-Strapi user. The value can be any identifier that uniquely distinguishes the reaction author in your system.
 
 **Example URL**: `https://localhost:1337/api/reactions/toggle/like/single/api::homepage.homepage?locale=en`
 **Example URL**: `https://localhost:1337/api/reactions/toggle/like/collection/api::post.post/njx99iv4p4txuqp307ye8625?locale=en`
@@ -469,9 +485,9 @@ true
 ```
 
 ### Possible scenarios
-1. No reaction set yet - after `toggle` reaction is set
-2. Single reaction already set - after `toogle` no reaction is set
-3. Multiple reactions already set - after `toggle` just specified reaction stays, rest becomes unset
+1. No reaction set yet - Calling `toggle` for a reaction sets that reaction.
+2. Same reaction already set - Calling `toggle` for a reaction that is already set will **unset** it (result: no reaction).
+3. Different reaction already set - If another reaction is set, calling `toggle` for a new reaction will **switch** to that reaction: the specified reaction becomes set, and any previously set reactions of that type are unset.
 
 ## 🕸️ Public GraphQL API specification
 
@@ -522,8 +538,10 @@ query {
 _REST API equivalent: [Public REST API -> List all reactions associated with Content Type](#list-all-reactions-associated-with-content-type)_
 
 Return all reactions associated with provided Collection / Single Type UID and Content Type Document ID with following combinations:
-- Query `reactionsList` - no `Authorization` header provided (open for public)
-- Query `reactionsListPerUser` - an `Authorization` header is mandatory
+- Query `reactionsList` – returns all reactions for the specified document. No `Authorization` header is required (public access).
+- Query `reactionsListPerUser` – returns reactions added by a specific author. One of the following headers is required:
+  - `Authorization` – to fetch reactions for a Strapi user.
+  - `X-Reactions-Author` – to fetch reactions for a non-Strapi user, identified by any custom author ID.
 
 **Example request**
 
@@ -600,7 +618,9 @@ query {
 _REST API equivalent: [Public REST API -> List all reactions associated with particular user](#list-all-reactions-associated-with-particular-user)_
 
 Return all reactions associated with provided user:
-- Query `reactionsListAllPerUser` - an `Authorization` header is mandatory or `userId` in args
+- Query `reactionsListAllPerUser` – one of the following headers is required:
+  - `Authorization` – to fetch reactions for a Strapi user.
+  - `X-Reactions-Author` – to fetch reactions for a non-Strapi user, identified by any custom author ID.
 
 **Example request**
 
@@ -666,8 +686,11 @@ query {
 _REST API equivalent: [Public REST API -> List all reactions of kind / type associated with Content Type](#list-all-reactions-of-kind--type-associated-with-content-type)_
 
 Return all reactions of specific kind / type associated with provided Collection / Single Type UID and Content Type Document ID with following combinations:
-- Query `reactionsList` - no `Authorization` header provided (open for public)
-- Query `reactionsListPerUser` - an `Authorization` header is mandatory
+- Query `reactionsList` – returns all reactions for the specified document. No `Authorization` header is required (public access).
+- Query `reactionsListPerUser` – returns reactions added by a specific author. One of the following headers is required:
+  - `Authorization` – to fetch reactions for a Strapi user.
+  - `X-Reactions-Author` – to fetch reactions for a non-Strapi user, identified by any custom author ID.
+
 
 **Example request**
 
@@ -726,7 +749,9 @@ query {
 _REST API equivalent: [Public REST API -> List all reactions of kind associated with particular user](#list-all-reactions-of-kind-associated-with-particular-user)_
 
 Return all reactions of specific kind associated with provided user:
-- Query `reactionsListAllPerUser` - an `Authorization` header is mandatory or `userId` in args
+- Query `reactionsListAllPerUser` – one of the following headers is required:
+  - `Authorization` – to fetch reactions for a Strapi user.
+  - `X-Reactions-Author` – to fetch reactions for a non-Strapi user, identified by any custom author ID.
 
 **Example request**
 
@@ -784,7 +809,10 @@ _REST API equivalent: [Public REST API -> Set reaction for Content Type](#set-re
 
 Create reaction of specific kind / type associated with provided Collection / Single Type UID and Content Type Document ID.
 
-`Authorization` header is required
+To identify the reaction author, you must provide **one** of the following headers:
+
+- `Authorization` – use this header if you want to set a reaction for a Strapi user.
+- `X-Reactions-Author` – use this header if you want to set a reaction for a non-Strapi user. The value can be any identifier that uniquely distinguishes the reaction author in your system.
 
 **Example request**
 
@@ -821,7 +849,10 @@ _REST API equivalent: [Public REST API -> Unset reaction for Content Type](#unse
 
 Delete reaction of specific kind / type associated with provided Collection / Single Type UID and Content Type Document ID.
 
-`Authorization` header is required
+To identify the reaction author, you must provide **one** of the following headers:
+
+- `Authorization` – use this header if you want to set a reaction for a Strapi user.
+- `X-Reactions-Author` – use this header if you want to set a reaction for a non-Strapi user. The value can be any identifier that uniquely distinguishes the reaction author in your system.
 
 **Example request**
 
@@ -858,7 +889,10 @@ _REST API equivalent: [Public REST API -> Toggle reaction for Content Type](#tog
 
 Toggle reaction of specific kind / type associated with provided Collection / Single Type UID and Content Type Document ID.
 
-`Authorization` header is required
+To identify the reaction author, you must provide **one** of the following headers:
+
+- `Authorization` – use this header if you want to set a reaction for a Strapi user.
+- `X-Reactions-Author` – use this header if you want to set a reaction for a non-Strapi user. The value can be any identifier that uniquely distinguishes the reaction author in your system.
 
 **Example request**
 
@@ -900,9 +934,9 @@ mutation reactionToggle {
 ```
 
 ### Possible scenarios
-1. No reaction set yet - after `toggle` reaction is set
-2. Single reaction already set - after `toogle` no reaction is set
-3. Multiple reactions already set - after `toggle` just specified reaction stays, rest becomes unset
+1. No reaction set yet - Calling `toggle` for a reaction sets that reaction.
+2. Same reaction already set - Calling `toggle` for a reaction that is already set will **unset** it (result: no reaction).
+3. Different reaction already set - If another reaction is set, calling `toggle` for a new reaction will **switch** to that reaction: the specified reaction becomes set, and any previously set reactions of that type are unset.
 
 ## 🔌 Enrich service for Strapi extensions
 

--- a/admin/src/pages/Settings/index.tsx
+++ b/admin/src/pages/Settings/index.tsx
@@ -68,7 +68,7 @@ const Settings = () => {
 
   const { fetch, submitMutation, deleteMutation } = useConfig(toggleNotification);
   const { syncAssociationsMutation } = useUtils(toggleNotification);
-
+  console.log("SETTIMGS PAGE")
   const {
     data,
     isLoading: isConfigLoading,

--- a/admin/src/pages/Settings/index.tsx
+++ b/admin/src/pages/Settings/index.tsx
@@ -68,7 +68,7 @@ const Settings = () => {
 
   const { fetch, submitMutation, deleteMutation } = useConfig(toggleNotification);
   const { syncAssociationsMutation } = useUtils(toggleNotification);
-  console.log("SETTIMGS PAGE")
+
   const {
     data,
     isLoading: isConfigLoading,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-reactions",
-  "version": "2.1.10",
+  "version": "2.2.0-beta.1",
   "description": "Strapi - Reactions plugin",
   "strapi": {
     "name": "reactions",
@@ -129,5 +129,6 @@
     "node": ">=18.0.0 <=22.x.x",
     "npm": ">=6.0.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "packageManager": "yarn@1.22.22"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-reactions",
-  "version": "2.2.0-beta.1",
+  "version": "2.2.0",
   "description": "Strapi - Reactions plugin",
   "strapi": {
     "name": "reactions",

--- a/server/src/content-types/reaction.ts
+++ b/server/src/content-types/reaction.ts
@@ -36,6 +36,11 @@ export default {
       target: "plugin::users-permissions.user",
       configurable: false,
     },
+    userId: {
+      type: "string",
+      configurable: false,
+      required: false,
+    },
     kind: {
       type: 'relation',
       relation: "manyToOne",

--- a/server/src/controllers/client.ts
+++ b/server/src/controllers/client.ts
@@ -38,7 +38,7 @@ export default () => ({
 
   async list(ctx: Context) {
     try {
-      const authorId = ctx.get('x-reactions-author');;
+      const authorId = ctx.get('x-reactions-author');
       const { params = {}, state: { user }, query = {} } = ctx;
       const { locale } = parseQuery(query);
       const { kind, uid, documentId } = parseParams<ReactionListUrlProps>(params);
@@ -50,7 +50,7 @@ export default () => ({
 
   async listPerUser(ctx: Context) {
     try {
-      const authorId = ctx.get('x-reactions-author');;
+      const authorId = ctx.get('x-reactions-author');
       const { params = {}, state: { user }, query = {} } = ctx;
       const { populate, filters, sort, pagination, locale } = parseQuery(query);
       const { kind, userId } = parseParams<ReactionListByUserUrlProps>(params);
@@ -68,6 +68,10 @@ export default () => ({
       } catch (e) {
         throw new PluginError(400, "User not found");
       }
+      console.log(authorId);
+      if (!targetUser && !authorId) {
+        throw new PluginError(400, "User ID must be provided via x-reactions-author header (custom users) or Authorization header (Strapi users");
+      }
 
       return await this.getService<IServiceClient>().listPerUser(targetUser, authorId, kind, {
         populate,
@@ -83,10 +87,15 @@ export default () => ({
 
   async create(ctx: Context) {
     try {
-      const authorId = ctx.get('x-reactions-author');;
+      const authorId = ctx.get('x-reactions-author');
       const { params = {}, state: { user }, query = {} } = ctx;
       const { kind, uid, documentId } = parseParams<ReactionsTypeUrlProps>(params);
       const { locale } = parseQuery(query);
+
+      if (!user && !authorId) {
+        throw new PluginError(400, "User ID must be provided via x-reactions-author header (custom users) or Bearer token (Strapi users");
+      }
+
       return await this.getService<IServiceClient>().create(kind, uid, user, documentId, locale, authorId);
     } catch (e) {
       throw throwError(ctx, e);
@@ -95,10 +104,15 @@ export default () => ({
 
   async delete(ctx: Context) {
     try {
-      const authorId = ctx.get('x-reactions-author');;
+      const authorId = ctx.get('x-reactions-author');
       const { params = {}, state: { user }, query = {} } = ctx;
       const { kind, uid, documentId } = parseParams<ReactionsTypeUrlProps>(params);
       const { locale } = parseQuery(query);
+
+      if (!user && !authorId) {
+        throw new PluginError(400, "User ID must be provided via x-reactions-author header (custom users) or Bearer token (Strapi users");
+      }
+
       return await this.getService<IServiceClient>().delete(kind, uid, user, documentId, locale, authorId);
     } catch (e) {
       throw throwError(ctx, e);
@@ -107,10 +121,15 @@ export default () => ({
 
   async toggle(ctx: Context) {
     try {
-      const authorId = ctx.get('x-reactions-author');;
+      const authorId = ctx.get('x-reactions-author');
       const { params = {}, state: { user }, query = {} } = ctx;
       const { kind, uid, documentId } = parseParams<ReactionsTypeUrlProps>(params);
       const { locale } = parseQuery(query);
+
+      if (!user && !authorId) {
+        throw new PluginError(400, "User ID must be provided via x-reactions-author header (custom users) or Bearer token (Strapi users");
+      }
+
       return await this.getService<IServiceClient>().toggle(kind, uid, user, documentId, locale, authorId);
     } catch (e) {
       throw throwError(ctx, e);

--- a/server/src/controllers/client.ts
+++ b/server/src/controllers/client.ts
@@ -8,6 +8,7 @@ import PluginError from "../utils/error";
 import { throwError } from './utils/functions';
 
 import { IServiceClient } from '../../../@types';
+import { getModelUid } from "../services/utils/functions";
 
 type ReactionListUrlProps = {
   kind?: string;
@@ -37,10 +38,11 @@ export default () => ({
 
   async list(ctx: Context) {
     try {
+      const authorId = ctx.get('x-reactions-author');;
       const { params = {}, state: { user }, query = {} } = ctx;
       const { locale } = parseQuery(query);
       const { kind, uid, documentId } = parseParams<ReactionListUrlProps>(params);
-      return await this.getService<IServiceClient>().list(kind, uid, user, documentId, locale);
+      return await this.getService<IServiceClient>().list(kind, uid, user, documentId, locale, authorId);
     } catch (e) {
       throw throwError(ctx, e);
     }
@@ -48,13 +50,14 @@ export default () => ({
 
   async listPerUser(ctx: Context) {
     try {
+      const authorId = ctx.get('x-reactions-author');;
       const { params = {}, state: { user }, query = {} } = ctx;
-      const { populate, filters, sort, pagination } = parseQuery(query);
+      const { populate, filters, sort, pagination, locale } = parseQuery(query);
       const { kind, userId } = parseParams<ReactionListByUserUrlProps>(params);
 
       let targetUser: unknown;
       try {
-        if (userId) {
+        if (userId && !authorId) {
           targetUser = await strapi
             .plugin("users-permissions")
             .service("user")
@@ -66,11 +69,12 @@ export default () => ({
         throw new PluginError(400, "User not found");
       }
 
-      return await this.getService<IServiceClient>().listPerUser(targetUser, kind, {
+      return await this.getService<IServiceClient>().listPerUser(targetUser, authorId, kind, {
         populate,
         filters,
         sort,
         pagination,
+        locale
       });
     } catch (e) {
       throw throwError(ctx, e);
@@ -79,10 +83,11 @@ export default () => ({
 
   async create(ctx: Context) {
     try {
+      const authorId = ctx.get('x-reactions-author');;
       const { params = {}, state: { user }, query = {} } = ctx;
       const { kind, uid, documentId } = parseParams<ReactionsTypeUrlProps>(params);
       const { locale } = parseQuery(query);
-      return await this.getService<IServiceClient>().create(kind, uid, user, documentId, locale);
+      return await this.getService<IServiceClient>().create(kind, uid, user, documentId, locale, authorId);
     } catch (e) {
       throw throwError(ctx, e);
     }
@@ -90,10 +95,11 @@ export default () => ({
 
   async delete(ctx: Context) {
     try {
+      const authorId = ctx.get('x-reactions-author');;
       const { params = {}, state: { user }, query = {} } = ctx;
       const { kind, uid, documentId } = parseParams<ReactionsTypeUrlProps>(params);
       const { locale } = parseQuery(query);
-      return await this.getService<IServiceClient>().delete(kind, uid, user, documentId, locale);
+      return await this.getService<IServiceClient>().delete(kind, uid, user, documentId, locale, authorId);
     } catch (e) {
       throw throwError(ctx, e);
     }
@@ -101,10 +107,11 @@ export default () => ({
 
   async toggle(ctx: Context) {
     try {
+      const authorId = ctx.get('x-reactions-author');;
       const { params = {}, state: { user }, query = {} } = ctx;
       const { kind, uid, documentId } = parseParams<ReactionsTypeUrlProps>(params);
       const { locale } = parseQuery(query);
-      return await this.getService<IServiceClient>().toggle(kind, uid, user, documentId, locale);
+      return await this.getService<IServiceClient>().toggle(kind, uid, user, documentId, locale, authorId);
     } catch (e) {
       throw throwError(ctx, e);
     }

--- a/server/src/graphql/mutations/set.ts
+++ b/server/src/graphql/mutations/set.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../../@types";
 
 import { getPluginService } from "../../utils/functions";
+import PluginError from "../../utils/error";
 
 type SetReactionProps = {
   input: ToBeFixed;
@@ -26,11 +27,17 @@ export default ({ nexus }: StrapiGraphQLContext) => {
       ctx: Context
     ) {
       const { input } = args;
-      const { state: { user = undefined } = {} } = ctx;
+      const { state: { user = undefined } = {}, koaContext } = ctx;
       const { kind, uid, documentId, locale } = input;
+      const authorId = koaContext.get('x-reactions-author');
+
+      if (!user && !authorId) {
+        throw new PluginError(400, "User ID must be provided via x-reactions-author header (custom users) or Authorization header (Strapi users");
+      }
+
       try {
         return await getPluginService<IServiceClient>("client")
-          .create(kind, uid, user, documentId, locale);
+          .create(kind, uid, user, documentId, locale, authorId);
       } catch (e: ToBeFixed) {
         throw new Error(e);
       }

--- a/server/src/graphql/mutations/toggle.ts
+++ b/server/src/graphql/mutations/toggle.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../../@types";
 
 import { getPluginService } from "../../utils/functions";
+import PluginError from "../../utils/error";
 
 type ToggleReactionProps = {
   input: ToBeFixed;
@@ -26,11 +27,17 @@ export default ({ nexus }: StrapiGraphQLContext) => {
       ctx: Context
     ) {
       const { input } = args;
-      const { state: { user = undefined } = {} } = ctx;
+      const { state: { user = undefined } = {}, koaContext } = ctx;
       const { kind, uid, documentId, locale } = input;
+      const authorId = koaContext.get('x-reactions-author');
+
+      if (!user && !authorId) {
+        throw new PluginError(400, "User ID must be provided via x-reactions-author header (custom users) or Authorization header (Strapi users");
+      }
+      
       try {
         return await getPluginService<IServiceClient>("client")
-          .toggle(kind, uid, user, documentId, locale);
+          .toggle(kind, uid, user, documentId, locale, authorId);
       } catch (e: ToBeFixed) {
         throw new Error(e);
       }

--- a/server/src/graphql/mutations/unset.ts
+++ b/server/src/graphql/mutations/unset.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../../@types";
 
 import { getPluginService } from "../../utils/functions";
+import PluginError from "../../utils/error";
 
 type UnsetReactionProps = {
   input: ToBeFixed;
@@ -26,11 +27,17 @@ export default ({ nexus }: StrapiGraphQLContext) => {
       ctx: Context
     ) {
       const { input } = args;
-      const { state: { user = undefined } = {} } = ctx;
+      const { state: { user = undefined } = {}, koaContext } = ctx;
       const { kind, uid, documentId, locale } = input;
+      const authorId = koaContext.get('x-reactions-author');
+
+      if (!user && !authorId) {
+        throw new PluginError(400, "User ID must be provided via x-reactions-author header (custom users) or Authorization header (Strapi users");
+      }
+
       try {
         return await getPluginService<IServiceClient>("client")
-          .delete(kind, uid, user, documentId, locale);
+          .delete(kind, uid, user, documentId, locale, authorId);
       } catch (e: ToBeFixed) {
         throw new Error(e);
       }

--- a/server/src/graphql/queries/list-all-per-user.ts
+++ b/server/src/graphql/queries/list-all-per-user.ts
@@ -28,7 +28,7 @@ export default ({ nexus }: StrapiGraphQLContext) => {
       ctx: Context) {
       const { kind, userId } = args;
       const { state: { user = undefined } = {} } = ctx;
-
+      console.log(ctx.headers)
       let targetUser = user;
       try {
         if (!targetUser && userId) {

--- a/server/src/graphql/queries/list-all-per-user.ts
+++ b/server/src/graphql/queries/list-all-per-user.ts
@@ -28,7 +28,7 @@ export default ({ nexus }: StrapiGraphQLContext) => {
       ctx: Context) {
       const { kind, userId } = args;
       const { state: { user = undefined } = {} } = ctx;
-      console.log(ctx.headers)
+
       let targetUser = user;
       try {
         if (!targetUser && userId) {

--- a/server/src/graphql/queries/list-all-per-user.ts
+++ b/server/src/graphql/queries/list-all-per-user.ts
@@ -27,7 +27,8 @@ export default ({ nexus }: StrapiGraphQLContext) => {
       args: ListAllPerUserResolverProps,
       ctx: Context) {
       const { kind, userId } = args;
-      const { state: { user = undefined } = {} } = ctx;
+      const { state: { user = undefined } = {}, koaContext } = ctx;
+      const authorId = koaContext.get('x-reactions-author');
 
       let targetUser = user;
       try {
@@ -41,7 +42,11 @@ export default ({ nexus }: StrapiGraphQLContext) => {
         throw new PluginError(400, "User not found");
       }
 
-      return await getPluginService<IServiceClient>("client").listPerUser(user, kind);
+      if (!targetUser && !authorId) {
+        throw new PluginError(400, "User ID must be provided via x-reactions-author header (custom users) or Authorization header (Strapi users");
+      }
+
+      return await getPluginService<IServiceClient>("client").listPerUser(user, authorId, kind);
     },
   };
 };

--- a/server/src/graphql/queries/list.ts
+++ b/server/src/graphql/queries/list.ts
@@ -12,6 +12,7 @@ type ListAllResolverProps = {
   uid: UID.ContentType;
   locale?: string;
   documentId?: Data.DocumentID;
+  authorId?: string;
 };
 
 export default ({ nexus }: StrapiGraphQLContext) => {
@@ -24,15 +25,16 @@ export default ({ nexus }: StrapiGraphQLContext) => {
       uid: nonNull(stringArg()),
       documentId: stringArg(),
       locale: stringArg(),
+      authorId: stringArg(),
     },
     async resolve(
       _: Object, 
       args: ListAllResolverProps,
       ctx: Context) {
-      const { kind, uid, documentId, locale } = args;
+      const { kind, uid, documentId, locale, authorId } = args;
       const { state: { user = undefined } = {} } = ctx;
 
-      return await getPluginService<IServiceClient>("client").list(kind, uid, user, documentId, locale);
+      return await getPluginService<IServiceClient>("client").list(kind, uid, user, documentId, locale, authorId);
     },
   };
 };

--- a/server/src/graphql/queries/list.ts
+++ b/server/src/graphql/queries/list.ts
@@ -12,7 +12,6 @@ type ListAllResolverProps = {
   uid: UID.ContentType;
   locale?: string;
   documentId?: Data.DocumentID;
-  authorId?: string;
 };
 
 export default ({ nexus }: StrapiGraphQLContext) => {
@@ -25,14 +24,14 @@ export default ({ nexus }: StrapiGraphQLContext) => {
       uid: nonNull(stringArg()),
       documentId: stringArg(),
       locale: stringArg(),
-      authorId: stringArg(),
     },
     async resolve(
       _: Object, 
       args: ListAllResolverProps,
       ctx: Context) {
-      const { kind, uid, documentId, locale, authorId } = args;
-      const { state: { user = undefined } = {} } = ctx;
+      const { kind, uid, documentId, locale } = args;
+      const { state: { user = undefined } = {}, koaContext } = ctx;
+      const authorId = koaContext.get('x-reactions-author');
 
       return await getPluginService<IServiceClient>("client").list(kind, uid, user, documentId, locale, authorId);
     },

--- a/server/src/graphql/resolvers-config.ts
+++ b/server/src/graphql/resolvers-config.ts
@@ -2,7 +2,8 @@ export default () => ({
 	'Query.reactionKinds': { auth: false },
 	'Query.reactionsList': { auth: false },
 	'Query.reactionsListPerUser': { auth: false },
-	'Mutation.reactionSet': { auth: true },
-	'Mutation.reactionUnset': { auth: true },
-	'Mutation.reactionToggle': { auth: true },
+	'Query.reactionsListAllPerUser': { auth: false },
+	'Mutation.reactionSet': { auth: false },
+	'Mutation.reactionUnset': { auth: false },
+	'Mutation.reactionToggle': { auth: false },
 });

--- a/server/src/graphql/resolvers-config.ts
+++ b/server/src/graphql/resolvers-config.ts
@@ -1,7 +1,7 @@
 export default () => ({
 	'Query.reactionKinds': { auth: false },
-	'Query.reactionsListAll': { auth: false },
-	'Query.reactionsListPerUser': { auth: true },
+	'Query.reactionsList': { auth: false },
+	'Query.reactionsListPerUser': { auth: false },
 	'Mutation.reactionSet': { auth: true },
 	'Mutation.reactionUnset': { auth: true },
 	'Mutation.reactionToggle': { auth: true },

--- a/server/src/graphql/types/reaction.ts
+++ b/server/src/graphql/types/reaction.ts
@@ -6,8 +6,9 @@ export default ({ nexus }: StrapiGraphQLContext) =>
     definition(t: INexusType) {
       t.id("documentId");
       t.nonNull.field("kind", { type: "ReactionType" });
-      t.nonNull.field("user", { type: "UsersPermissionsUser" });
+      t.field("user", { type: "UsersPermissionsUser" });
       t.field("related", { type: "ReactionRelated" });
+      t.string("userId");
       t.string("locale");
       t.string("createdAt");
       t.string("updatedAt");

--- a/server/src/services/client.ts
+++ b/server/src/services/client.ts
@@ -71,6 +71,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
           $eq: authorId,
         },
       };
+      fields = [...fields, 'userId'];
     } else if (!isNil(user)) {
       filters = {
         ...filters,
@@ -83,6 +84,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
           fields: ['documentId', 'username', 'email']
         },
       };
+      fields = [...fields, 'userId'];
     }
 
     const entities = await strapi
@@ -247,15 +249,12 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     const existingReactions = await this.list(undefined, uid, user, documentId, locale, authorId);
     const matchingReaction = existingReactions
       .find(({ kind: { slug } }) => kind === slug);
-      
+
     if (matchingReaction) {
       return this.directDelete(existingReactions, locale);
     }
 
-    const reactionsToRemove = existingReactions
-      .filter(({ documentId: reactionId }) => reactionId !== matchingReaction?.documentId);
-
-    const removed = await this.directDelete(reactionsToRemove, locale);
+    const removed = await this.directDelete(existingReactions, locale);
 
     if (!removed) {
       throw new PluginError(405, `Can't perform toggle action reaction type of "${kind}" for Entity with Document ID: ${documentId || 'single'} of type: ${uid}`);

--- a/server/src/services/client.ts
+++ b/server/src/services/client.ts
@@ -103,8 +103,8 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
 
   async listPerUser(
     this: IServiceClient,
-    user: unknown,
-    userId: string,
+    user?: unknown,
+    userId?: string,
     kind?: string,
     query?: StrapiQueryParamsParsed,
   ): Promise<Array<CTReaction>> {
@@ -188,7 +188,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     this: IServiceClient,
     kind: string,
     uid: UID.ContentType,
-    user: StrapiUser,
+    user?: StrapiUser,
     documentId?: Data.DocumentID,
     locale?: string,
     authorId?: string,
@@ -232,7 +232,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     this: IServiceClient,
     kind: string,
     uid: UID.ContentType,
-    user: StrapiUser,
+    user?: StrapiUser,
     documentId?: Data.DocumentID,
     locale?: string,
     authorId?: string,
@@ -253,12 +253,12 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     }
 
     const reactionsToRemove = existingReactions
-      .filter(({ documentId: reactionId }) => reactionId !== matchingReaction.documentId);
+      .filter(({ documentId: reactionId }) => reactionId !== matchingReaction?.documentId);
 
     const removed = await this.directDelete(reactionsToRemove, locale);
 
     if (!removed) {
-      throw new PluginError(405, `Can't perform toogle action reaction type of "${kind}" for Entity with Document ID: ${documentId || 'single'} of type: ${uid}`);
+      throw new PluginError(405, `Can't perform toggle action reaction type of "${kind}" for Entity with Document ID: ${documentId || 'single'} of type: ${uid}`);
     }
 
     if (isNil(matchingReaction)) {
@@ -266,8 +266,6 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     } else {
       return matchingReaction;
     }
-
-
   },
 
   async prefetchConditions(
@@ -326,7 +324,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     uid: UID.ContentType,
     kind: CTReactionType,
     related: AnyEntity,
-    user: StrapiUser,
+    user?: StrapiUser,
     locale?: string,
     authorId?: string,
   ): Promise<CTReaction> {
@@ -358,6 +356,5 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       })));
     return removedEntities && (removedEntities.length === reactions.length);
   },
-
 
 });

--- a/server/tests/services/client.test.ts
+++ b/server/tests/services/client.test.ts
@@ -88,7 +88,7 @@ describe("Test client service", () => {
       
       const documentsInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[0].value;
       expect(documentsInstance.findMany).toHaveBeenCalledWith({
-        fields: ["createdAt", "updatedAt"],
+        fields: ["createdAt", "updatedAt", "userId"],
         filters: {
           relatedUid: {
             $contains: "",
@@ -121,7 +121,7 @@ describe("Test client service", () => {
       
       const reactionInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[1].value;
       expect(reactionInstance.findMany).toHaveBeenCalledWith({
-        fields: ["createdAt", "updatedAt"],
+        fields: ["createdAt", "updatedAt", "userId"],
         filters: {
           relatedUid: {
             $contains: "",
@@ -170,7 +170,7 @@ describe("Test client service", () => {
       
       const reactionInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[1].value;
       expect(reactionInstance.findMany).toHaveBeenCalledWith({
-        fields: ["createdAt", "updatedAt"],
+        fields: ["createdAt", "updatedAt", "userId"],
         filters: {
           relatedUid: {
             $eq: "api::article.article:123",

--- a/server/tests/services/client.test.ts
+++ b/server/tests/services/client.test.ts
@@ -1,0 +1,672 @@
+import { setupStrapi, resetStrapi } from "../initSetup";
+import { getPluginService } from "../../src/utils/functions";
+import { IServiceClient } from "../../../@types";
+
+describe("Test client service", () => {
+  const mockReactionTypes = [
+    {
+      documentId: "type-1",
+      slug: "like",
+      name: "Like",
+      icon: { id: 1, url: "/icon.png" },
+    },
+    {
+      documentId: "type-2",
+      slug: "love",
+      name: "Love",
+      icon: null,
+    },
+  ];
+
+  const mockUser = {
+    documentId: "user-1",
+    username: "testuser",
+    email: "test@example.com",
+  };
+
+  const mockReactions = [
+    {
+      documentId: "reaction-1",
+      kind: { documentId: "type-1", slug: "like", name: "Like" },
+      user: mockUser,
+      relatedUid: "api::article.article:1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      documentId: "reaction-2",
+      kind: { documentId: "type-2", slug: "love", name: "Love" },
+      user: { documentId: "user-2", username: "testuser2", email: "test2@example.com" },
+      relatedUid: "api::article.article:2",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  ];
+
+  const mockRelatedEntity = {
+    documentId: "123",
+    title: "Test Article",
+    locale: "en",
+  };
+
+  beforeEach(() => {
+    setupStrapi({}, false, {}, {
+      "plugins::reactions.reaction-type": mockReactionTypes,
+      "plugins::reactions.reaction": mockReactions,
+      "api::article.article": [mockRelatedEntity],
+    });
+  });
+
+  afterEach(() => {
+    resetStrapi();
+  });
+
+  describe("kinds", () => {
+    it("should find kinds and return data", async () => {
+
+      const service = getPluginService<IServiceClient>("client");
+      const result = await service.kinds();
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction-type");
+      
+      const documentsInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[0].value;
+      expect(documentsInstance.findMany).toHaveBeenCalledWith({
+        populate: ["icon"],
+      });
+      
+      expect(result).toEqual(mockReactionTypes);
+    });
+  });
+
+  describe("list", () => {
+    it("should return list of all reactions when no parameters provided", async () => {
+
+      const service = getPluginService<IServiceClient>("client");
+      await service.list();
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction");
+      
+      const documentsInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[0].value;
+      expect(documentsInstance.findMany).toHaveBeenCalledWith({
+        fields: ["createdAt", "updatedAt"],
+        filters: {
+          relatedUid: {
+            $contains: "",
+          },
+        },
+        populate: {
+          kind: {
+            fields: ["slug", "name"],
+          },
+          user: {
+            fields: ["documentId", "username", "email"],
+          },
+        },
+        locale: undefined,
+      });
+    });
+
+    it("should find many with kind filter when only kind parameter is provided", async () => {
+
+      const service = getPluginService<IServiceClient>("client");
+      await service.list("like");
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction-type");
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction");
+      
+      const reactionTypeInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[0].value;
+      expect(reactionTypeInstance.findFirst).toHaveBeenCalledWith({
+        filters: { slug: "like" },
+      });
+      
+      const reactionInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[1].value;
+      expect(reactionInstance.findMany).toHaveBeenCalledWith({
+        fields: ["createdAt", "updatedAt"],
+        filters: {
+          relatedUid: {
+            $contains: "",
+          },
+          kind: mockReactionTypes[0],
+        },
+        populate: {
+          user: {
+            fields: ["documentId", "username", "email"],
+          },
+        },
+        locale: undefined,
+      });
+    });
+
+    it("should find many with all filters when all params provided with user and without authorId", async () => {
+
+      const service = getPluginService<IServiceClient>("client");
+      await service.list("like", "api::article.article", mockUser, "123", "en");
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction-type");
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction");
+      
+      const reactionInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[1].value;
+      expect(reactionInstance.findMany).toHaveBeenCalledWith({
+        fields: ["createdAt", "updatedAt"],
+        filters: {
+          relatedUid: {
+            $eq: "api::article.article:123",
+          },
+          kind: mockReactionTypes[0],
+          user: mockUser,
+        },
+        populate: {},
+        locale: "en",
+      });
+    });
+
+    it("should find many with all filters when all params provided without user and with authorId", async () => {
+
+      const service = getPluginService<IServiceClient>("client");
+      await service.list("like", "api::article.article", undefined, "123", "en", "author-123");
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction-type");
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction");
+      
+      const reactionInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[1].value;
+      expect(reactionInstance.findMany).toHaveBeenCalledWith({
+        fields: ["createdAt", "updatedAt"],
+        filters: {
+          relatedUid: {
+            $eq: "api::article.article:123",
+          },
+          kind: mockReactionTypes[0],
+          userId: {
+            $eq: "author-123",
+          },
+        },
+        populate: {},
+        locale: "en",
+      });
+    });
+  });
+
+  describe("listPerUser", () => {
+    it("should find reactions per user when only user is provided", async () => {
+
+      const service = getPluginService<IServiceClient>("client");
+      await service.listPerUser(mockUser, undefined);
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction");
+      
+      const reactionInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[0].value;
+      expect(reactionInstance.findMany).toHaveBeenCalledWith({
+        fields: ["createdAt", "updatedAt", "relatedUid"],
+        filters: {
+          user: mockUser,
+        },
+        populate: {
+          related: true,
+          kind: {
+            fields: ["slug", "name"],
+          },
+        },
+        sort: undefined,
+        pagination: undefined,
+        locale: "*",
+      });
+    });
+
+    it("should find reactions per user when only userId is provided", async () => {
+
+      const service = getPluginService<IServiceClient>("client");
+      await service.listPerUser(undefined, "user-1");
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction");
+      
+      const reactionInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[0].value;
+      expect(reactionInstance.findMany).toHaveBeenCalledWith({
+        fields: ["createdAt", "updatedAt", "relatedUid"],
+        filters: {
+          userId: "user-1",
+        },
+        populate: {
+          related: true,
+          kind: {
+            fields: ["slug", "name"],
+          },
+        },
+        sort: undefined,
+        pagination: undefined,
+        locale: "*",
+      });
+    });
+
+    it("should find reactions per user and userId when both user and userId are provided", async () => {
+      setupStrapi({}, false, {}, {
+        "plugins::reactions.reaction": [
+          {
+            documentId: "reaction-1",
+            kind: mockReactionTypes[0],
+            userId: "user-2",
+            relatedUid: "api::article.article:1",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        ],
+      });
+
+      const service = getPluginService<IServiceClient>("client");
+      await service.listPerUser(mockUser, "user-2");
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction");
+      
+      const reactionInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[0].value;
+      expect(reactionInstance.findMany).toHaveBeenCalledWith({
+        fields: ["createdAt", "updatedAt", "relatedUid"],
+        filters: {
+          user: mockUser,
+          userId: "user-2",
+        },
+        populate: {
+          related: true,
+          kind: {
+            fields: ["slug", "name"],
+          },
+        },
+        sort: undefined,
+        pagination: undefined,
+        locale: "*",
+      });
+    });
+
+    it("should find reactions per user with kind filter", async () => {
+
+      const service = getPluginService<IServiceClient>("client");
+      await service.listPerUser(mockUser, undefined, "like");
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction-type");
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction");
+      
+      const reactionInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[1].value;
+      expect(reactionInstance.findMany).toHaveBeenCalledWith({
+        fields: ["createdAt", "updatedAt", "relatedUid"],
+        filters: {
+          user: mockUser,
+          kind: mockReactionTypes[0],
+        },
+        populate: {
+          related: true,
+        },
+        sort: undefined,
+        pagination: undefined,
+        locale: "*",
+      });
+    });
+  });
+
+  describe("create", () => {
+    it("should create reaction when no existing reaction found", async () => {
+      setupStrapi({}, false, {}, {
+        "plugins::reactions.reaction-type": [mockReactionTypes[0]],
+        "plugins::reactions.reaction": [],
+        "api::article.article": [mockRelatedEntity],
+      });
+
+      const service = getPluginService<IServiceClient>("client");
+      await service.create("like", "api::article.article", mockUser, "123", "en");
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction-type");
+      expect(global.strapi.documents).toHaveBeenCalledWith("api::article.article");
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction");
+
+      const reactionInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[4].value;
+      expect(reactionInstance.create).toHaveBeenCalledWith({
+        data: {
+          kind: mockReactionTypes[0],
+          related: {
+            ...mockRelatedEntity,
+            __type: "api::article.article",
+          },
+          relatedUid: "api::article.article:123",
+          user: mockUser,
+          userId: undefined,
+        },
+        locale: "en",
+      });
+    });
+
+    it("should create reaction with authorId when provided", async () => {
+      setupStrapi({}, false, {}, {
+        "plugins::reactions.reaction-type": [mockReactionTypes[0]],
+        "plugins::reactions.reaction": [],
+        "api::article.article": [mockRelatedEntity],
+      });
+
+      const service = getPluginService<IServiceClient>("client");
+      await service.create("like", "api::article.article", mockUser, "123", "en", "author-123");
+
+      const reactionInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[4].value;
+      expect(reactionInstance.create).toHaveBeenCalledWith({
+        data: {
+          kind: mockReactionTypes[0],
+          related: {
+            ...mockRelatedEntity,
+            __type: "api::article.article",
+          },
+          relatedUid: "api::article.article:123",
+          user: mockUser,
+          userId: "author-123",
+        },
+        locale: "en",
+      });
+    });
+
+    it("should throw error when reaction already exists", async () => {
+      const existingReaction = {
+        documentId: "reaction-1",
+        kind: mockReactionTypes[0],
+        user: mockUser,
+        relatedUid: "api::article.article:123",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      setupStrapi({}, false, {}, {
+        "plugins::reactions.reaction-type": [mockReactionTypes[0]],
+        "plugins::reactions.reaction": [existingReaction],
+        "api::article.article": [mockRelatedEntity],
+      });
+
+      const service = getPluginService<IServiceClient>("client");
+      
+      await expect(
+        service.create("like", "api::article.article", mockUser, "123", "en")
+      ).rejects.toThrow("Can't perform CREATE on reaction type of \"like\" for Entity with ID: 123 of type: api::article.article as it already exist");
+    });
+  });
+
+  describe("delete", () => {
+    it("should delete reaction when exactly one reaction found", async () => {
+      const existingReaction = {
+        documentId: "reaction-1",
+        kind: mockReactionTypes[0],
+        user: mockUser,
+        relatedUid: "api::article.article:123",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      setupStrapi({}, false, {}, {
+        "plugins::reactions.reaction-type": [mockReactionTypes[0]],
+        "plugins::reactions.reaction": [existingReaction],
+      });
+
+      const service = getPluginService<IServiceClient>("client");
+      await service.delete("like", "api::article.article", mockUser, "123", "en");
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction-type");
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction");
+      
+      const reactionInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[2].value;
+      expect(reactionInstance.delete).toHaveBeenCalledWith({
+        documentId: "reaction-1",
+        locale: "en",
+      });
+    });
+
+    it("should delete reaction with authorId when provided", async () => {
+      const existingReaction = {
+        documentId: "reaction-1",
+        kind: mockReactionTypes[0],
+        userId: "author-123",
+        relatedUid: "api::article.article:123",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      setupStrapi({}, false, {}, {
+        "plugins::reactions.reaction-type": [mockReactionTypes[0]],
+        "plugins::reactions.reaction": [existingReaction],
+      });
+
+      const service = getPluginService<IServiceClient>("client");
+
+      await service.delete("like", "api::article.article", mockUser, "123", "en", "author-123");
+
+      const reactionInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[2].value;
+      expect(reactionInstance.delete).toHaveBeenCalledWith({
+        documentId: "reaction-1",
+        locale: "en",
+      });
+    });
+
+    it("should throw error when no reaction found", async () => {
+      setupStrapi({}, false, {}, {
+        "plugins::reactions.reaction-type": [mockReactionTypes[0]],
+        "plugins::reactions.reaction": [],
+      });
+
+      const service = getPluginService<IServiceClient>("client");
+      
+      await expect(
+        service.delete("like", "api::article.article", mockUser, "123", "en")
+      ).rejects.toThrow("Can't perform DELETE on reaction type of \"like\" for Entity with ID: 123 of type: api::article.article");
+    });
+
+    it("should throw error when multiple reactions found", async () => {
+      const existingReactions = [
+        {
+          documentId: "reaction-1",
+          kind: mockReactionTypes[0],
+          user: mockUser,
+          relatedUid: "api::article.article:123",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          documentId: "reaction-2",
+          kind: mockReactionTypes[0],
+          user: mockUser,
+          relatedUid: "api::article.article:123",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      setupStrapi({}, false, {}, {
+        "plugins::reactions.reaction-type": [mockReactionTypes[0]],
+        "plugins::reactions.reaction": existingReactions,
+      });
+
+      const service = getPluginService<IServiceClient>("client");
+      
+      await expect(
+        service.delete("like", "api::article.article", mockUser, "123", "en")
+      ).rejects.toThrow("Can't perform DELETE on reaction type of \"like\" for Entity with ID: 123 of type: api::article.article");
+    });
+  });
+
+  describe("toggle", () => {
+    it("should delete all reactions when toggling existing reaction", async () => {
+      const existingReactions = [
+        {
+          documentId: "reaction-1",
+          kind: { documentId: "type-1", slug: "like", name: "Like" },
+          user: mockUser,
+          relatedUid: "api::article.article:123",
+          locale: "en",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          documentId: "reaction-2",
+          kind: { documentId: "type-2", slug: "love", name: "Love" },
+          user: mockUser,
+          relatedUid: "api::article.article:123",
+          locale: "en",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      setupStrapi({}, false, {}, {
+        "plugins::reactions.reaction-type": mockReactionTypes,
+        "plugins::reactions.reaction": existingReactions,
+        "api::article.article": [mockRelatedEntity],
+      });
+
+      const service = getPluginService<IServiceClient>("client");
+      await service.toggle("like", "api::article.article", mockUser, "123", "en");
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction-type");
+      expect(global.strapi.documents).toHaveBeenCalledWith("api::article.article");
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction");
+
+      const reactionInstance1 = (global.strapi.documents as unknown as jest.Mock).mock.results[3].value;
+      expect(reactionInstance1.delete).toHaveBeenCalledWith({
+        documentId: "reaction-1",
+        locale: "en",
+      });
+      const reactionInstance2 = (global.strapi.documents as unknown as jest.Mock).mock.results[4].value;
+      expect(reactionInstance2.delete).toHaveBeenCalledWith({
+        documentId: "reaction-2",
+        locale: "en",
+      });
+    });
+
+    it("should remove all existing reactions and create a new reaction when no matching reaction exists", async () => {
+      const existingReactions = [
+        {
+          documentId: "reaction-2",
+          kind: { documentId: "type-2", slug: "love", name: "Love" },
+          user: mockUser,
+          relatedUid: "api::article.article:123",
+          locale: "en",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      setupStrapi({}, false, {}, {
+        "plugins::reactions.reaction-type": mockReactionTypes,
+        "plugins::reactions.reaction": existingReactions,
+        "api::article.article": [mockRelatedEntity],
+      });
+
+      const service = getPluginService<IServiceClient>("client");
+      await service.toggle("like", "api::article.article", mockUser, "123", "en");
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction-type");
+      expect(global.strapi.documents).toHaveBeenCalledWith("api::article.article");
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction");
+      
+      const documentsMock = global.strapi.documents as unknown as jest.Mock;
+      const reactionInstances = documentsMock.mock.results
+        .map((result, index) => ({
+          uid: documentsMock.mock.calls[index][0],
+          instance: result.value,
+        }))
+        .filter(({ uid }) => uid === "plugins::reactions.reaction");
+      
+      const deleteCalls = reactionInstances.flatMap(({ instance }) => 
+        (instance.delete as jest.Mock).mock.calls
+      );
+      expect(deleteCalls).toContainEqual([{ documentId: "reaction-2", locale: "en" }]);
+      
+      const createCalls = reactionInstances.flatMap(({ instance }) => 
+        (instance.create as jest.Mock).mock.calls
+      );
+      expect(createCalls).toContainEqual([{
+        data: {
+          kind: mockReactionTypes[0],
+          related: {
+            ...mockRelatedEntity,
+            __type: "api::article.article",
+          },
+          relatedUid: "api::article.article:123",
+          user: mockUser,
+          userId: undefined,
+        },
+        locale: "en",
+      }]);
+    });
+
+    it("should create reaction when no existing reactions", async () => {
+      setupStrapi({}, false, {}, {
+        "plugins::reactions.reaction-type": [mockReactionTypes[0]],
+        "plugins::reactions.reaction": [],
+        "api::article.article": [mockRelatedEntity],
+      });
+
+      const service = getPluginService<IServiceClient>("client");
+      await service.toggle("like", "api::article.article", mockUser, "123", "en");
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction-type");
+      expect(global.strapi.documents).toHaveBeenCalledWith("api::article.article");
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction");
+      
+      const documentsMock = global.strapi.documents as unknown as jest.Mock;
+      const reactionInstances = documentsMock.mock.results
+        .map((result, index) => ({
+          uid: documentsMock.mock.calls[index][0],
+          instance: result.value,
+        }))
+        .filter(({ uid }) => uid === "plugins::reactions.reaction");
+      
+      // Check that create was called
+      const createCalls = reactionInstances.flatMap(({ instance }) => 
+        (instance.create as jest.Mock).mock.calls
+      );
+      expect(createCalls).toContainEqual([{
+        data: {
+          kind: mockReactionTypes[0],
+          related: {
+            ...mockRelatedEntity,
+            __type: "api::article.article",
+          },
+          relatedUid: "api::article.article:123",
+          user: mockUser,
+          userId: undefined,
+        },
+        locale: "en",
+      }]);
+    });
+
+    it("should toggle with authorId when provided", async () => {
+      const existingReactions = [
+        {
+          documentId: "reaction-1",
+          kind: { documentId: "type-1", slug: "like", name: "Like" },
+          userId: "author-123",
+          relatedUid: "api::article.article:123",
+          locale: "en",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      setupStrapi({}, false, {}, {
+        "plugins::reactions.reaction-type": [mockReactionTypes[0]],
+        "plugins::reactions.reaction": existingReactions,
+        "api::article.article": [mockRelatedEntity],
+      });
+
+      const service = getPluginService<IServiceClient>("client");
+      await service.toggle("like", "api::article.article", mockUser, "123", "en", "author-123");
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction-type");
+      expect(global.strapi.documents).toHaveBeenCalledWith("api::article.article");
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction");
+      
+      const documentsMock = global.strapi.documents as unknown as jest.Mock;
+      const reactionInstances = documentsMock.mock.results
+        .map((result, index) => ({
+          uid: documentsMock.mock.calls[index][0],
+          instance: result.value,
+        }))
+        .filter(({ uid }) => uid === "plugins::reactions.reaction");
+      
+      // Check that delete was called
+      const deleteCalls = reactionInstances.flatMap(({ instance }) => 
+        (instance.delete as jest.Mock).mock.calls
+      );
+      expect(deleteCalls).toContainEqual([{ documentId: "reaction-1", locale: "en" }]);
+    });
+  });
+});


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-reactions/issues/38

## Summary

 - added `X-Reactions-Author` header that supports non-Strapi reaction author data
 - added checking if `Authorization` or `X-Reactions-Author` header is provided
 - updated tests
 - updated `README`
