### PR TITLE
fix: list per user

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-reactions",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Strapi - Reactions plugin",
   "strapi": {
     "name": "reactions",

--- a/server/src/controllers/client.ts
+++ b/server/src/controllers/client.ts
@@ -68,7 +68,7 @@ export default () => ({
       } catch (e) {
         throw new PluginError(400, "User not found");
       }
-      console.log(authorId);
+
       if (!targetUser && !authorId) {
         throw new PluginError(400, "User ID must be provided via x-reactions-author header (custom users) or Authorization header (Strapi users");
       }

--- a/server/src/services/client.ts
+++ b/server/src/services/client.ts
@@ -117,8 +117,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     let fields = ['createdAt', 'updatedAt', 'relatedUid'];
     let filters: Record<string, any> = {
       ...(isObject(query?.filters) ? query?.filters : {}),
-      ...(isObject(user) ? { user } : {}),
-      ...(userId ? { userId } : {})
+      ...(userId ? { userId } : isObject(user) ? { user } : {})
     };
     let populate: StrapiRequestQueryPopulateClause = {
       related: true,

--- a/server/tests/services/client.test.ts
+++ b/server/tests/services/client.test.ts
@@ -237,7 +237,7 @@ describe("Test client service", () => {
       });
     });
 
-    it("should find reactions per user and userId when both user and userId are provided", async () => {
+    it("should find reactions per user when both user and userId are provided (userId takes precedence)", async () => {
       setupStrapi({}, false, {}, {
         "plugins::reactions.reaction": [
           {
@@ -260,7 +260,6 @@ describe("Test client service", () => {
       expect(reactionInstance.findMany).toHaveBeenCalledWith({
         fields: ["createdAt", "updatedAt", "relatedUid"],
         filters: {
-          user: mockUser,
           userId: "user-2",
         },
         populate: {


### PR DESCRIPTION
## Summary

This PR fixes the way the`/list/user` endpoint works - it checks the `X-Reactions-Author` header first and applies the API Token user search only in case this header is not provided. It also removes unnecessary logs