### PR TITLE
Feat: add blockedAuthorProps property

### DIFF
--- a/@types/config.d.ts
+++ b/@types/config.d.ts
@@ -1,4 +1,5 @@
-import { ReactionTypeEntity } from "./model";
+import type { ReactionTypeEntity, CTReactionType } from "./model";
+import type { NotificationsContextValue } from "@strapi/strapi/admin";
 
 export type ReactionsPluginStoreConfig = {
   blockedAuthorProps: Array<string>;
@@ -8,6 +9,23 @@ export type ReactionsPluginStoreConfig = {
 };
 
 export type ReactionsPluginConfig = {
-    types: Array<ReactionTypeEntity>;
-    config: ReactionsPluginStoreConfig;
+  types: Array<ReactionTypeEntity>;
+  config: ReactionsPluginStoreConfig;
+};
+
+export type EditableReactionsPluginConfig = Pick<
+  ReactionsPluginStoreConfig,
+  "blockedAuthorProps"
+>;
+
+export type ToggleNotification = NotificationsContextValue["toggleNotification"];
+
+export type SubmitPayload = {
+  body: CTReactionType;
+  toggleNotification: ToggleNotification;
+};
+
+export type UpdateConfigPayload = {
+  blockedAuthorProps: string[];
+  toggleNotification: ToggleNotification;
 };

--- a/@types/config.d.ts
+++ b/@types/config.d.ts
@@ -1,6 +1,13 @@
 import { ReactionTypeEntity } from "./model";
 
+export type ReactionsPluginStoreConfig = {
+  blockedAuthorProps: Array<string>;
+  gql?: {
+    reactionRelated?: Array<string>;
+  };
+};
+
 export type ReactionsPluginConfig = {
     types: Array<ReactionTypeEntity>;
-    config: any;
+    config: ReactionsPluginStoreConfig;
 };

--- a/@types/services.d.ts
+++ b/@types/services.d.ts
@@ -10,12 +10,20 @@ import { CTReaction, CTReactionType } from "./model";
 
 export interface IServiceCommon {
   getPluginStore(): any;
+  getLocalConfig<K extends keyof import('./config').ReactionsPluginStoreConfig>(
+    prop: K,
+    defaultValue?: import('./config').ReactionsPluginStoreConfig[K],
+  ): import('./config').ReactionsPluginStoreConfig[K];
+  getConfig<K extends keyof import('./config').ReactionsPluginStoreConfig>(
+    prop?: K,
+    defaultValue?: import('./config').ReactionsPluginStoreConfig[K],
+  ): Promise<import('./config').ReactionsPluginStoreConfig | import('./config').ReactionsPluginStoreConfig[K]>;
 }
 
 export interface IServiceAdmin {
   fetchConfig<T extends ReactionsPluginConfig>(): Promise<T>;
   updateConfig(
-    body: CTReactionType,
+    body: Pick<ReactionsPluginConfig['config'], 'blockedAuthorProps'>,
   ): Promise<ReactionsPluginConfig>;
   deleteReactionType(documentId: Data.DocumentID): Promise<{ result: boolean }>;
   generateSlug(subject: string, documentId?: Data.DocumentID): Promise<{ slug: string }>;
@@ -24,6 +32,8 @@ export interface IServiceAdmin {
 }
 
 export interface IServiceClient {
+  getCommonService(): IServiceCommon;
+  sanitizeReactions(entities: Array<CTReaction>): Promise<Array<CTReaction>>;
   kinds(): Promise<Array<AnyEntity>>;
   list(kind?: string, uid?: UID.ContentType, user?: StrapiUser, documentId?: Data.DocumentID, locale?: string, authorId?: string): Promise<Array<AnyEntity>>;
   listPerUser(user: StrapiUser, userId: string, kind?: string, populate?: StrapiQueryParamsParsed): Promise<Array<AnyEntity>>;
@@ -36,6 +46,8 @@ export interface IServiceClient {
 }
 
 export interface IServiceEnrich {
+  getCommonService(): IServiceCommon;
+  sanitizeReactions(reactions: Array<CTReaction>): Promise<Array<CTReaction>>;
   enrichOne<T extends AnyEntity, M extends any>(uid: UID.ContentType, response: T, populate: ToBeFixed, locale?: string): Promise<T>;
   enrichMany<T extends AnyEntity, M extends any>(uid: UID.ContentType, response: T, populate: ToBeFixed, locale?: string): Promise<T>;
   findReactions(filters: any, populate: ToBeFixed, locale?: string): null | AnyEntity | Array<AnyEntity>;

--- a/@types/services.d.ts
+++ b/@types/services.d.ts
@@ -1,4 +1,4 @@
-import { Data, UID } from "@strapi/strapi";
+import { Core, Data, UID } from "@strapi/strapi";
 import { AnyEntity, StrapiUser, StrapiQueryParamsParsed } from "@sensinum/strapi-vl-utils";
 
 import { ToBeFixed } from "./common";
@@ -9,7 +9,7 @@ import { ReactionsPluginConfig } from "./config";
 import { CTReaction, CTReactionType } from "./model";
 
 export interface IServiceCommon {
-  getPluginStore(): any;
+  getPluginStore(): Promise<ReturnType<Core.Strapi['store']>>;
   getLocalConfig<K extends keyof import('./config').ReactionsPluginStoreConfig>(
     prop: K,
     defaultValue?: import('./config').ReactionsPluginStoreConfig[K],

--- a/@types/services.d.ts
+++ b/@types/services.d.ts
@@ -5,25 +5,27 @@ import { ToBeFixed } from "./common";
 import { type PrefetchConditionsProps } from "../server/src/services/client";
 import { StrapiReactions } from "../server/src/services/enrich";
 import { ReactionsCount } from "../server/src/services/zone";
-import { ReactionsPluginConfig } from "./config";
-import { CTReaction, CTReactionType } from "./model";
+import type { EditableReactionsPluginConfig, ReactionsPluginConfig, ReactionsPluginStoreConfig } from "./config";
+import type { CTReaction, CTReactionType } from "./model";
 
 export interface IServiceCommon {
   getPluginStore(): Promise<ReturnType<Core.Strapi['store']>>;
-  getLocalConfig<K extends keyof import('./config').ReactionsPluginStoreConfig>(
+  getLocalConfig(): ReactionsPluginStoreConfig;
+  getLocalConfig<K extends keyof ReactionsPluginStoreConfig>(
     prop: K,
-    defaultValue?: import('./config').ReactionsPluginStoreConfig[K],
-  ): import('./config').ReactionsPluginStoreConfig[K];
-  getConfig<K extends keyof import('./config').ReactionsPluginStoreConfig>(
+    defaultValue?: ReactionsPluginStoreConfig[K],
+  ): ReactionsPluginStoreConfig[K];
+  getConfig(): Promise<ReactionsPluginStoreConfig>;
+  getConfig<K extends keyof ReactionsPluginStoreConfig>(
     prop?: K,
-    defaultValue?: import('./config').ReactionsPluginStoreConfig[K],
-  ): Promise<import('./config').ReactionsPluginStoreConfig | import('./config').ReactionsPluginStoreConfig[K]>;
+    defaultValue?: ReactionsPluginStoreConfig[K],
+  ): Promise<ReactionsPluginStoreConfig[K]>;
 }
 
 export interface IServiceAdmin {
   fetchConfig<T extends ReactionsPluginConfig>(): Promise<T>;
   updateConfig(
-    body: Pick<ReactionsPluginConfig['config'], 'blockedAuthorProps'>,
+    body: EditableReactionsPluginConfig,
   ): Promise<ReactionsPluginConfig>;
   createReactionType(
     body: CTReactionType,

--- a/@types/services.d.ts
+++ b/@types/services.d.ts
@@ -25,6 +25,12 @@ export interface IServiceAdmin {
   updateConfig(
     body: Pick<ReactionsPluginConfig['config'], 'blockedAuthorProps'>,
   ): Promise<ReactionsPluginConfig>;
+  createReactionType(
+    body: CTReactionType,
+  ): Promise<CTReactionType>;
+  updateReactionType(
+    body: CTReactionType,
+  ): Promise<CTReactionType>;
   deleteReactionType(documentId: Data.DocumentID): Promise<{ result: boolean }>;
   generateSlug(subject: string, documentId?: Data.DocumentID): Promise<{ slug: string }>;
   uniqueSlug(slug: string, documentId?: Data.DocumentID): Promise<string>;

--- a/admin/src/hooks/useConfig.ts
+++ b/admin/src/hooks/useConfig.ts
@@ -60,7 +60,10 @@ const useConfig = (toggleNotification: any, client?: any): useConfigResult => {
   };
 
   const submitMutation = useMutation({
-    mutationFn: ({ body }: SubmitPayload) => updateConfig(body, config),
+    mutationFn: ({ body }: SubmitPayload) =>
+      body.documentId
+        ? updateReactionType(body, config)
+        : createReactionType(body, config),
     onSuccess: () => handleSuccess("submit"),
     onError: () => handleError("submit"),
   });

--- a/admin/src/hooks/useConfig.ts
+++ b/admin/src/hooks/useConfig.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient, UseQueryResult, UseMutationResult } from '@tanstack/react-query';
 import { useIntl } from "react-intl";
-import { useFetchClient } from '@strapi/strapi/admin';
+import { NotificationsContextValue, useFetchClient } from '@strapi/strapi/admin';
 
 import {
   fetchConfig,
@@ -10,17 +10,7 @@ import {
   deleteReactionType,
 } from "../pages/Settings/utils/api";
 import { pluginId } from "../pluginId";
-import { CTReactionType } from '../../../@types';
-
-type SubmitPayload = {
-  body: CTReactionType;
-  toggleNotification: any;
-};
-
-type UpdateConfigPayload = {
-  blockedAuthorProps: string[];
-  toggleNotification: any;
-};
+import type { ToggleNotification, SubmitPayload, UpdateConfigPayload } from '../../../@types';
 
 export type useConfigResult = {
   fetch: UseQueryResult<any, Error>;
@@ -29,7 +19,7 @@ export type useConfigResult = {
   deleteMutation: UseMutationResult<any, Error>;
 };
 
-const useConfig = (toggleNotification: any, client?: any): useConfigResult => {
+const useConfig = (toggleNotification: ToggleNotification, client?: any): useConfigResult => {
   const queryClient = useQueryClient(client);
   const fetchClient = useFetchClient();
   const { formatMessage } = useIntl();

--- a/admin/src/hooks/useConfig.ts
+++ b/admin/src/hooks/useConfig.ts
@@ -4,6 +4,8 @@ import { useFetchClient } from '@strapi/strapi/admin';
 
 import {
   fetchConfig,
+  createReactionType,
+  updateReactionType,
   updateConfig,
   deleteReactionType,
 } from "../pages/Settings/utils/api";
@@ -15,9 +17,15 @@ type SubmitPayload = {
   toggleNotification: any;
 };
 
+type UpdateConfigPayload = {
+  blockedAuthorProps: string[];
+  toggleNotification: any;
+};
+
 export type useConfigResult = {
   fetch: UseQueryResult<any, Error>;
   submitMutation: UseMutationResult<any, Error, SubmitPayload>;
+  updateConfigMutation: UseMutationResult<any, Error, UpdateConfigPayload>;
   deleteMutation: UseMutationResult<any, Error>;
 };
 
@@ -68,6 +76,12 @@ const useConfig = (toggleNotification: any, client?: any): useConfigResult => {
     onError: () => handleError("submit"),
   });
 
+  const updateConfigMutation = useMutation({
+    mutationFn: ({ blockedAuthorProps }: UpdateConfigPayload) => updateConfig({ blockedAuthorProps }, config),
+    onSuccess: () => handleSuccess("pluginConfig"),
+    onError: () => handleError("pluginConfig"),
+  });
+
   const deleteMutation = useMutation({
     mutationFn: ({ documentId }: any) => deleteReactionType(documentId, config),
     onSuccess: () => handleSuccess("reaction.delete"),
@@ -75,7 +89,7 @@ const useConfig = (toggleNotification: any, client?: any): useConfigResult => {
   });
 
 
-  return { fetch, submitMutation, deleteMutation };
+  return { fetch, submitMutation, updateConfigMutation, deleteMutation };
 };
 
 export default useConfig;

--- a/admin/src/injections/EditViewSummary/index.tsx
+++ b/admin/src/injections/EditViewSummary/index.tsx
@@ -40,7 +40,7 @@ type ContentManagerQueryParams = {
 
 export const EditViewSummary = () => {
     const location = useLocation();
-    const toggleNotification = useNotification();
+    const { toggleNotification } = useNotification();
 
     const groups: ContentManagerPathProps = new RegExp(CONTENT_MANAGER_PATH_PATTERN, "gm")
         .exec(location.pathname)?.groups as ContentManagerPathProps;

--- a/admin/src/pages/Settings/common/const.ts
+++ b/admin/src/pages/Settings/common/const.ts
@@ -1,0 +1,6 @@
+export const BOX_DEFAULT_PROPS = {
+  background: 'neutral0',
+  hasRadius: true,
+  shadow: 'filterShadow',
+  padding: 6,
+};

--- a/admin/src/pages/Settings/components/AdditionalSettingsPanel/index.tsx
+++ b/admin/src/pages/Settings/components/AdditionalSettingsPanel/index.tsx
@@ -24,7 +24,7 @@ export const AdditionalSettingsPanel = ({
   onSubmit,
 }: AdditionalSettingsPanelProps) => {
   return (
-    <Box {...BOX_DEFAULT_PROPS}>
+    <Box width="100%" {...BOX_DEFAULT_PROPS}>
       <Typography variant="delta" as="h2">
         {getMessage("page.settings.section.additionalSettings.title")}
       </Typography>

--- a/admin/src/pages/Settings/components/AdditionalSettingsPanel/index.tsx
+++ b/admin/src/pages/Settings/components/AdditionalSettingsPanel/index.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { Form } from "@strapi/strapi/admin";
+import {
+  Box,
+  Button,
+  Field,
+  Flex,
+  Grid,
+  Typography,
+} from "@strapi/design-system";
+import { Check } from "@strapi/icons";
+import { getMessage } from "../../../../utils";
+import { BOX_DEFAULT_PROPS } from "../../common/const";
+
+type AdditionalSettingsPanelProps = {
+  blockedAuthorProps: string[];
+  isSubmitting: boolean;
+  onSubmit: (values: { blockedAuthorProps: string }) => Promise<void>;
+};
+
+export const AdditionalSettingsPanel = ({
+  blockedAuthorProps,
+  isSubmitting,
+  onSubmit,
+}: AdditionalSettingsPanelProps) => {
+  return (
+    <Box {...BOX_DEFAULT_PROPS}>
+      <Typography variant="delta" as="h2">
+        {getMessage("page.settings.section.additionalSettings.title")}
+      </Typography>
+      <Box padding={1} />
+      <Form
+        method="POST"
+        width="auto"
+        height="auto"
+        onSubmit={onSubmit}
+        initialValues={{
+          blockedAuthorProps: blockedAuthorProps.join(", "),
+        }}
+      >
+        {({ values, onChange }) => (
+          <>
+            <Grid.Root gap={4} width="100%">
+              <Grid.Item col={12} s={12} xs={12}>
+                <Field.Root
+                  width="100%"
+                  hint={getMessage(
+                    "page.settings.form.blockedAuthorProps.hint",
+                  )}
+                >
+                  <Field.Label htmlFor="blockedAuthorProps">
+                    {getMessage("page.settings.form.blockedAuthorProps.label")}
+                  </Field.Label>
+                  <Field.Input
+                    name="blockedAuthorProps"
+                    value={values.blockedAuthorProps}
+                    onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                      onChange("blockedAuthorProps", event.target.value);
+                    }}
+                  />
+                  <Field.Hint />
+                </Field.Root>
+              </Grid.Item>
+            </Grid.Root>
+            <Flex justifyContent="flex-end">
+              <Button
+                type="submit"
+                startIcon={<Check />}
+                loading={isSubmitting}
+              >
+                {getMessage("page.settings.action.savePluginConfig")}
+              </Button>
+            </Flex>
+          </>
+        )}
+      </Form>
+    </Box>
+  );
+};

--- a/admin/src/pages/Settings/index.tsx
+++ b/admin/src/pages/Settings/index.tsx
@@ -7,7 +7,7 @@ import {
   Layouts,
   useNotification,
   useRBAC,
-  useStrapiApp
+  useStrapiApp,
 } from '@strapi/strapi/admin';
 
 import {
@@ -39,15 +39,9 @@ import CUModal from "./components/Modal";
 import { ReactionIcon } from "./components/ReactionIcon";
 import useUtils from "../../hooks/useUtils";
 import { AdminAction } from "./components/AdminAction";
+import { AdditionalSettingsPanel } from "./components/AdditionalSettingsPanel";
 import { CTReactionType, ToBeFixed } from "../../../../@types";
-
-const DEFAULT_BOX_PROPS = {
-  width: "100%",
-  background: "neutral0",
-  hasRadius: true,
-  shadow: "filterShadow",
-  padding: 6,
-};
+import { BOX_DEFAULT_PROPS } from "./common/const";
 
 const Settings = () => {
   const { toggleNotification } = useNotification();
@@ -66,7 +60,7 @@ const Settings = () => {
   const [modalEntity, setModalEntity] = useState<CTReactionType | undefined>(undefined);
   const [entityToDelete, setEntityToDelete] = useState<CTReactionType>();
 
-  const { fetch, submitMutation, deleteMutation } = useConfig(toggleNotification);
+  const { fetch, submitMutation, updateConfigMutation, deleteMutation } = useConfig(toggleNotification);
   const { syncAssociationsMutation } = useUtils(toggleNotification);
 
   const {
@@ -75,7 +69,8 @@ const Settings = () => {
     err: configErr,
   }: any = fetch;
 
-  const { types = [] } = data || {};
+  const { types = [], config = {} } = data || {};
+  const blockedAuthorProps = config.blockedAuthorProps ?? [];
 
   const isLoading =
     isLoadingForPermissions ||
@@ -142,6 +137,18 @@ const Settings = () => {
       } finally {
         setSyncAssiciationConfirmationVisible(false);
       }
+    }
+  };
+
+  const handleConfigSubmit = async (values: { blockedAuthorProps: string }) => {
+    if (canChange) {
+      await updateConfigMutation.mutateAsync({
+        blockedAuthorProps: values.blockedAuthorProps
+          .split(',')
+          .map((prop: string) => prop.trim())
+          .filter(Boolean),
+        toggleNotification,
+      });
     }
   };
 
@@ -250,8 +257,15 @@ const Settings = () => {
               </Tbody>
             </Table>
           </Box>
+          {canChange && (
+            <AdditionalSettingsPanel
+              blockedAuthorProps={blockedAuthorProps}
+              isSubmitting={updateConfigMutation.isPending}
+              onSubmit={handleConfigSubmit}
+            />
+          )}
           {canAdmin && (
-            <Box {...DEFAULT_BOX_PROPS}>
+            <Box {...BOX_DEFAULT_PROPS}>
               <Flex width="100%" direction="column" gap={4}>
                 <Flex width="100%" direction="column" gap={2} alignItems="flexStart">
                   <Typography variant="delta" tag="h2">

--- a/admin/src/pages/Settings/index.tsx
+++ b/admin/src/pages/Settings/index.tsx
@@ -167,7 +167,7 @@ const Settings = () => {
         <Layouts.Header
           title={getMessage("page.settings.header.title")}
           subtitle={getMessage("page.settings.header.description")}
-          primaryAction={canChange && (<>
+          primaryAction={canChange && (
             <Button
               type="submit"
               startIcon={<Plus />}
@@ -175,7 +175,7 @@ const Settings = () => {
             >
               {getMessage("page.settings.action.create")}
             </Button>
-          </>)}
+          )}
         />
         <Layouts.Content>
           <Flex direction="column" gap={6}>
@@ -231,7 +231,7 @@ const Settings = () => {
                           <IconButton onClick={() => handleOpenModal(entry)} label={getMessage("page.settings.table.action.edit")} noBorder>
                             <Pencil />
                           </IconButton>
-                          {( canChange) && (<ConfirmationDialog
+                          {canChange && (<ConfirmationDialog
                               isVisible={entityToDelete?.documentId === entry.documentId}
                               isLoading={deleteMutation.isPending}
                               title={getMessage("page.settings.modal.title.delete")}

--- a/admin/src/pages/Settings/index.tsx
+++ b/admin/src/pages/Settings/index.tsx
@@ -161,167 +161,170 @@ const Settings = () => {
   }
 
   return (
-    <Page.Main>
-      <Page.Title>{getMessage("page.settings.header.title")}</Page.Title>
-      <Layouts.Header
-        title={getMessage("page.settings.header.title")}
-        subtitle={getMessage("page.settings.header.description")}
-        primaryAction={canChange && (<>
-          <Button
-            type="submit"
-            startIcon={<Plus />}
-            onClick={(e: React.FormEvent) => { e.preventDefault(); handleOpenModal(); }}
-          >
-            {getMessage("page.settings.action.create")}
-          </Button>
-        </>)}
-      />
-      <Layouts.Content>
-        <Flex direction="column" gap={6}>
-          <Box width="100%" hasRadius={false}>
-            <Table colCount={5} rowCount={types.length} footer={canChange && (<TFooter
+    <Layouts.Root>
+      <Page.Main>
+        <Page.Title>{getMessage("page.settings.header.title")}</Page.Title>
+        <Layouts.Header
+          title={getMessage("page.settings.header.title")}
+          subtitle={getMessage("page.settings.header.description")}
+          primaryAction={canChange && (<>
+            <Button
+              type="submit"
+              startIcon={<Plus />}
               onClick={(e: React.FormEvent) => { e.preventDefault(); handleOpenModal(); }}
-              icon={<Plus />}>
-              {getMessage("page.settings.table.action.add")}
-            </TFooter>)}>
-              <Thead>
-                <Tr>
-                  <Th>
-                    <Typography variant="sigma">{getMessage("page.settings.table.headers.icon")}</Typography>
-                  </Th>
-                  <Th>
-                    <Typography variant="sigma">{getMessage("page.settings.table.headers.name")}</Typography>
-                  </Th>
-                  <Th>
-                    <Typography variant="sigma">{getMessage("page.settings.table.headers.slug")}</Typography>
-                  </Th>
-                  <Th>
-                    <Typography variant="sigma">{getMessage("page.settings.table.headers.usedIn")}</Typography>
-                  </Th>
-                  <Th>
-                    <VisuallyHidden>{getMessage("page.settings.table.headers.actions")}</VisuallyHidden>
-                  </Th>
-                </Tr>
-              </Thead>
-              <Tbody>
-                {types.map((entry: ToBeFixed) => <Tr key={entry.documentId}>
-                  <Td>
-                    {(entry.icon && !entry.emoji) && (<ReactionIcon src={entry.icon?.url} />)}
-                    {(!entry.icon && entry.emoji) && (<Typography variant="omega">{entry.emoji}</Typography>)}
-                  </Td>
-                  <Td>
-                    <Typography textColor="neutral800">
-                      {entry.name}
-                    </Typography>
-                  </Td>
-                  <Td>
-                    <Typography textColor="neutral800">
-                      {entry.slug}
-                    </Typography>
-                  </Td>
-                  <Td>
-                    <Typography textColor="neutral800">
+            >
+              {getMessage("page.settings.action.create")}
+            </Button>
+          </>)}
+        />
+        <Layouts.Content>
+          <Flex direction="column" gap={6}>
+            <Box width="100%" hasRadius={false}>
+              <Table colCount={5} rowCount={types.length} footer={canChange && (<TFooter
+                onClick={(e: React.FormEvent) => { e.preventDefault(); handleOpenModal(); }}
+                icon={<Plus />}>
+                {getMessage("page.settings.table.action.add")}
+              </TFooter>)}>
+                <Thead>
+                  <Tr>
+                    <Th>
+                      <Typography variant="sigma">{getMessage("page.settings.table.headers.icon")}</Typography>
+                    </Th>
+                    <Th>
+                      <Typography variant="sigma">{getMessage("page.settings.table.headers.name")}</Typography>
+                    </Th>
+                    <Th>
+                      <Typography variant="sigma">{getMessage("page.settings.table.headers.slug")}</Typography>
+                    </Th>
+                    <Th>
+                      <Typography variant="sigma">{getMessage("page.settings.table.headers.usedIn")}</Typography>
+                    </Th>
+                    <Th>
+                      <VisuallyHidden>{getMessage("page.settings.table.headers.actions")}</VisuallyHidden>
+                    </Th>
+                  </Tr>
+                </Thead>
+                <Tbody>
+                  {types.map((entry: ToBeFixed) => <Tr key={entry.documentId}>
+                    <Td>
+                      {(entry.icon && !entry.emoji) && (<ReactionIcon src={entry.icon?.url} />)}
+                      {(!entry.icon && entry.emoji) && (<Typography variant="omega">{entry.emoji}</Typography>)}
+                    </Td>
+                    <Td>
+                      <Typography textColor="neutral800">
+                        {entry.name}
+                      </Typography>
+                    </Td>
+                    <Td>
+                      <Typography textColor="neutral800">
+                        {entry.slug}
+                      </Typography>
+                    </Td>
+                    <Td>
+                      <Typography textColor="neutral800">
 
-                    </Typography>
-                  </Td>
-                  <Td>
-                    {canChange && (<Flex width="100%" justifyContent="flex-end" alignItems="center">
-                      <IconButtonGroup>
-                        <IconButton onClick={() => handleOpenModal(entry)} label={getMessage("page.settings.table.action.edit")} noBorder>
-                          <Pencil />
-                        </IconButton>
-                        {( canChange) && (<ConfirmationDialog
-                            isVisible={entityToDelete?.documentId === entry.documentId}
-                            isLoading={deleteMutation.isPending}
-                            title={getMessage("page.settings.modal.title.delete")}
-                            labelCancel={getMessage("page.settings.modal.action.delete.cancel")}
-                            labelConfirm={getMessage("page.settings.modal.action.delete.submit")}
-                            iconConfirm={<Trash />}
-                            onConfirm={() => handleDelete(entityToDelete?.documentId)}
-                            onClose={handleDeleteDiscard}
-                            trigger={<IconButton variant="danger-light" onClick={() => handleDeleteConfirmation(entry)} label={getMessage("page.settings.table.action.delete")} noBorder>
-                              <Trash />
-                            </IconButton>}
-                          >
-                            {getMessage({
-                              id: "page.settings.modal.description.delete",
-                              props: {
-                                name: entityToDelete?.name,
-                              },
-                            })}
-                          </ConfirmationDialog>)}
-                      </IconButtonGroup>
-                    </Flex>)}
-                  </Td>
-                </Tr>)}
-              </Tbody>
-            </Table>
-          </Box>
-          {canChange && (
-            <AdditionalSettingsPanel
-              blockedAuthorProps={blockedAuthorProps}
-              isSubmitting={updateConfigMutation.isPending}
-              onSubmit={handleConfigSubmit}
-            />
-          )}
-          {canAdmin && (
-            <Box {...BOX_DEFAULT_PROPS}>
-              <Flex width="100%" direction="column" gap={4}>
-                <Flex width="100%" direction="column" gap={2} alignItems="flexStart">
-                  <Typography variant="delta" tag="h2">
-                    {getMessage("page.settings.section.administrationTools.title")}
-                  </Typography>
-                  <Typography variant="pi" tag="h4">
-                    {getMessage("page.settings.section.administrationTools.subtitle")}
-                  </Typography>
-                </Flex>
-                <Flex width="100%" direction="column" gap={2} alignItems="flexStart">
-                  <Divider />
-                  <Grid.Root width="100%" gap={4} marginBottom={2}>
-                    <Grid.Item col={12} s={12} xs={12}>
-                      <AdminAction
-                        title={getMessage("page.settings.action.syncAssociations.title")}
-                        description={getMessage("page.settings.action.syncAssociations.description")}
-                        tip={getMessage("page.settings.action.syncAssociations.tip")}>
-                        <ConfirmationDialog
-                          isVisible={syncAssiciationConfirmationVisible}
-                          isLoading={syncAssociationsMutation.isPending}
-                          title={getMessage("page.settings.modal.title.syncAssociations")}
-                          labelCancel={getMessage("page.settings.modal.action.syncAssociations.cancel")}
-                          labelConfirm={getMessage("page.settings.modal.action.syncAssociations.submit")}
-                          iconConfirm={<ArrowClockwise />}
-                          onConfirm={handleSyncAssociations}
-                          onClose={handleSyncAssociationsCancel}
-                          trigger={<Button
-                            variant="danger-light"
-                            startIcon={<ArrowClockwise />}
-                            onClick={handleSyncAssociationsConfirmation}
-                          >
-                            {getMessage("page.settings.action.syncAssociations.button")}
-                          </Button>}
-                        >
-                          {getMessage(
-                            "page.settings.modal.description.syncAssociations"
-                          )}
-                        </ConfirmationDialog>
-                      </AdminAction>
-                    </Grid.Item>
-                  </Grid.Root>
-                </Flex>
-              </Flex>
+                      </Typography>
+                    </Td>
+                    <Td>
+                      {canChange && (<Flex width="100%" justifyContent="flex-end" alignItems="center">
+                        <IconButtonGroup>
+                          <IconButton onClick={() => handleOpenModal(entry)} label={getMessage("page.settings.table.action.edit")} noBorder>
+                            <Pencil />
+                          </IconButton>
+                          {( canChange) && (<ConfirmationDialog
+                              isVisible={entityToDelete?.documentId === entry.documentId}
+                              isLoading={deleteMutation.isPending}
+                              title={getMessage("page.settings.modal.title.delete")}
+                              labelCancel={getMessage("page.settings.modal.action.delete.cancel")}
+                              labelConfirm={getMessage("page.settings.modal.action.delete.submit")}
+                              iconConfirm={<Trash />}
+                              onConfirm={() => handleDelete(entityToDelete?.documentId)}
+                              onClose={handleDeleteDiscard}
+                              trigger={<IconButton variant="danger-light" onClick={() => handleDeleteConfirmation(entry)} label={getMessage("page.settings.table.action.delete")} noBorder>
+                                <Trash />
+                              </IconButton>}
+                            >
+                              {getMessage({
+                                id: "page.settings.modal.description.delete",
+                                props: {
+                                  name: entityToDelete?.name,
+                                },
+                              })}
+                            </ConfirmationDialog>)}
+                        </IconButtonGroup>
+                      </Flex>)}
+                    </Td>
+                  </Tr>)}
+                </Tbody>
+              </Table>
             </Box>
-          )}
-        </Flex>
+            {canChange && (
+              <AdditionalSettingsPanel
+                blockedAuthorProps={blockedAuthorProps}
+                isSubmitting={updateConfigMutation.isPending}
+                onSubmit={handleConfigSubmit}
+              />
+            )}
+            {canAdmin && (
+              <Box width="100%" {...BOX_DEFAULT_PROPS}>
+                <Flex width="100%" direction="column" gap={4}>
+                  <Flex width="100%" direction="column" gap={2} alignItems="flexStart">
+                    <Typography variant="delta" tag="h2">
+                      {getMessage("page.settings.section.administrationTools.title")}
+                    </Typography>
+                    <Typography variant="pi" tag="h4">
+                      {getMessage("page.settings.section.administrationTools.subtitle")}
+                    </Typography>
+                  </Flex>
+                  <Flex width="100%" direction="column" gap={2} alignItems="flexStart">
+                    <Divider />
+                    <Grid.Root width="100%" gap={4} marginBottom={2}>
+                      <Grid.Item col={12} s={12} xs={12}>
+                        <AdminAction
+                          title={getMessage("page.settings.action.syncAssociations.title")}
+                          description={getMessage("page.settings.action.syncAssociations.description")}
+                          tip={getMessage("page.settings.action.syncAssociations.tip")}>
+                          <ConfirmationDialog
+                            isVisible={syncAssiciationConfirmationVisible}
+                            isLoading={syncAssociationsMutation.isPending}
+                            title={getMessage("page.settings.modal.title.syncAssociations")}
+                            labelCancel={getMessage("page.settings.modal.action.syncAssociations.cancel")}
+                            labelConfirm={getMessage("page.settings.modal.action.syncAssociations.submit")}
+                            iconConfirm={<ArrowClockwise />}
+                            onConfirm={handleSyncAssociations}
+                            onClose={handleSyncAssociationsCancel}
+                            trigger={<Button
+                              variant="danger-light"
+                              startIcon={<ArrowClockwise />}
+                              onClick={handleSyncAssociationsConfirmation}
+                            >
+                              {getMessage("page.settings.action.syncAssociations.button")}
+                            </Button>}
+                          >
+                            {getMessage(
+                              "page.settings.modal.description.syncAssociations"
+                            )}
+                          </ConfirmationDialog>
+                        </AdminAction>
+                      </Grid.Item>
+                    </Grid.Root>
+                  </Flex>
+                </Flex>
+              </Box>
+            )}
+          </Flex>
 
-        {(isModalOpened && canChange) && (<CUModal
-          isModalOpened={isModalOpened}
-          data={modalEntity}
-          fields={fields}
-          isLoading={submitMutation.isPending}
-          onSubmit={handleCUD}
-          onClose={handleCloseModal} />)}
-      </Layouts.Content>
-    </Page.Main>);
+          {(isModalOpened && canChange) && (<CUModal
+            isModalOpened={isModalOpened}
+            data={modalEntity}
+            fields={fields}
+            isLoading={submitMutation.isPending}
+            onSubmit={handleCUD}
+            onClose={handleCloseModal} />)}
+        </Layouts.Content>
+      </Page.Main>
+    </Layouts.Root>
+  );
 };
 
 export default Settings;

--- a/admin/src/pages/Settings/utils/api.ts
+++ b/admin/src/pages/Settings/utils/api.ts
@@ -28,6 +28,22 @@ export const fetchConfig = async ({ toggleNotification, fetchClient }: FetchConf
   }
 };
 
+export const updateConfig = async (
+  body: { blockedAuthorProps: string[] },
+  { toggleNotification, fetchClient }: FetchConfig,
+): Promise<ReactionsPluginConfig | undefined> => {
+  try {
+    const { data } = await fetchClient.put(
+      getApiURL(`settings/config`),
+      body,
+    );
+
+    return data;
+  } catch (err) {
+    handleAPIError(err, toggleNotification);
+  }
+};
+
 export const createReactionType = async (
   body: CTReactionType,
   { toggleNotification, fetchClient }: FetchConfig,

--- a/admin/src/pages/Settings/utils/api.ts
+++ b/admin/src/pages/Settings/utils/api.ts
@@ -1,8 +1,7 @@
-import { isNil } from "lodash";
 import { Data } from "@strapi/strapi";
 import { getApiURL, handleAPIError } from "../../../utils";
 import qs from "qs";
-import { ReactionsPluginConfig, ToBeFixed } from "../../../../../@types";
+import { ReactionsPluginConfig, CTReactionType, ToBeFixed } from "../../../../../@types";
 
 export type FetchConfig = {
   toggleNotification: ToBeFixed;
@@ -29,11 +28,29 @@ export const fetchConfig = async ({ toggleNotification, fetchClient }: FetchConf
   }
 };
 
-export const updateConfig = async (body: ToBeFixed, { toggleNotification, fetchClient }: FetchConfig): Promise<ReactionsPluginConfig | undefined> => {
+export const createReactionType = async (
+  body: CTReactionType,
+  { toggleNotification, fetchClient }: FetchConfig,
+): Promise<ReactionsPluginConfig | undefined> => {
   try {
-    const method = isNil(body.documentId) ? fetchClient.post : fetchClient.put;
-    const { data } = await method(
-      getApiURL(`settings/config`),
+    const { data } = await fetchClient.post(
+      getApiURL(`settings/config/reaction-type`),
+      body,
+    );
+
+    return data;
+  } catch (err) {
+    handleAPIError(err, toggleNotification);
+  }
+};
+
+export const updateReactionType = async (
+  body: CTReactionType,
+  { toggleNotification, fetchClient }: FetchConfig,
+): Promise<ReactionsPluginConfig | undefined> => {
+  try {
+    const { data } = await fetchClient.put(
+      getApiURL(`settings/config/reaction-type`),
       body,
     );
 

--- a/admin/src/pages/SettingsInit/index.tsx
+++ b/admin/src/pages/SettingsInit/index.tsx
@@ -1,10 +1,7 @@
-import React from "react";
-
 import {
   QueryClient,
   QueryClientProvider,
 } from '@tanstack/react-query';
-
 import Settings from "../Settings";
 import { DesignSystemProvider } from "@strapi/design-system";
 import { usePluginTheme } from "@sensinum/strapi-utils";
@@ -12,7 +9,7 @@ import { usePluginTheme } from "@sensinum/strapi-utils";
 const queryClient = new QueryClient();
 
 const SettingsInit = () => {
-  const { theme } = usePluginTheme();
+  const theme = usePluginTheme();
   return (
     <QueryClientProvider client={queryClient}>
       <DesignSystemProvider theme={theme}>

--- a/admin/src/translations/en.ts
+++ b/admin/src/translations/en.ts
@@ -14,6 +14,7 @@ const en = {
       },
       action : {
         create: "Add new reaction",
+        savePluginConfig: "Save settings",
         syncAssociations: {
           title: "Associations synchronization",
           description: "Perform synchronization of reactions associations to make the search keys be up-to-date",
@@ -22,6 +23,9 @@ const en = {
         },
       },
       section: {
+        additionalSettings: {
+          title: "Additional settings",
+        },
         administrationTools: {
           title: "Administration tools",
           subtitle: "Special purpose tools and actions which you can perform in the global plugin context",
@@ -66,6 +70,10 @@ const en = {
         },
       },
       form: {
+        blockedAuthorProps: {
+          label: "Blocked user details",
+          hint: "Specified properties will be filtered out from user details in public API responses (comma-separated)",
+        },
         name: {
           label: "Name",
           required: "Name is required",
@@ -105,6 +113,10 @@ const en = {
       },
       loading: "Loading configuration...",
       notification: {
+        pluginConfig: {
+          success: "Plugin settings saved successfully",
+          error: "Something went wrong. Try again",
+        },
         submit: {
           success: "Reaction type submitted successfully",
           error: "Something went wrong. Try again",

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -1,4 +1,22 @@
-export default {
-  default: {},
-  validator() {},
+import { z } from 'zod';
+import { CONFIG_PARAMS } from '../utils/constants';
+
+const defaultPluginConfig: ReactionsPluginStoreConfig = {
+  blockedAuthorProps: [],
 };
+
+export const schemaConfig = z.object({
+  [CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS]: z.array(z.string()),
+  gql: z.object({
+    reactionRelated: z.array(z.string()).optional(),
+  }).optional(),
+});
+
+export type ReactionsPluginStoreConfig = z.infer<typeof schemaConfig>;
+
+const config = {
+  default: schemaConfig.parse(defaultPluginConfig),
+  validate: (config: unknown) => schemaConfig.safeParse(config),
+} as const;
+
+export default config;

--- a/server/src/controllers/settings.ts
+++ b/server/src/controllers/settings.ts
@@ -41,7 +41,7 @@ export default () => ({
     }
   },
 
-  async update(ctx: Context) {
+  async updateConfig(ctx: Context) {
     try {
       const { request: { body }} = ctx;
       if (body) {

--- a/server/src/controllers/settings.ts
+++ b/server/src/controllers/settings.ts
@@ -29,11 +29,23 @@ export default () => ({
     }
   },
 
-  async create(ctx: Context) {
+  async createReactionType(ctx: Context) {
     try {
       const { request: { body }} = ctx;
       if (body) {
-        return await this.getService<IServiceAdmin>().updateConfig(body);
+        return await this.getService<IServiceAdmin>().createReactionType(body);
+      }
+      throw throwError(ctx, new PluginError(400, 'Bad Request'));
+    } catch (e) {
+      throw throwError(ctx, e);
+    }
+  },
+
+  async updateReactionType(ctx: Context) {
+    try {
+      const { request: { body }} = ctx;
+      if (body) {
+        return await this.getService<IServiceAdmin>().updateReactionType(body);
       }
       throw throwError(ctx, new PluginError(400, 'Bad Request'));
     } catch (e) {

--- a/server/src/graphql/config.ts
+++ b/server/src/graphql/config.ts
@@ -2,7 +2,7 @@ import { Core } from "@strapi/strapi";
 
 import { getModelUid } from "../services/utils/functions";
 import { getPluginService } from "../utils/functions";
-import { IServiceCommon } from "../../../@types";
+import { IServiceAdmin, ReactionsPluginConfig } from "../../../@types";
 
 import getTypes from "./types";
 import getQueries from "./queries";
@@ -15,9 +15,8 @@ export default async ({ strapi }: { strapi: Core.Strapi }) => {
   extensionService.shadowCRUD(getModelUid('reaction')).disable();
   extensionService.shadowCRUD(getModelUid('reaction-type')).disable();
 
-  const commonService = getPluginService<IServiceCommon>('common');
-  const pluginStore = commonService.getPluginStore()
-  const config = await pluginStore.get({ key: 'config' });
+  const config: ReactionsPluginConfig = await getPluginService<IServiceAdmin>("admin")
+    .fetchConfig();
 
   extensionService.use(({ strapi, nexus }: any) => {
     const types = getTypes({ strapi, nexus, config });

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -9,8 +9,16 @@ const routes = [
   },
   {
     method: 'POST',
-    path: '/settings/config',
-    handler: 'settingsController.create',
+    path: '/settings/config/reaction-type',
+    handler: 'settingsController.createReactionType',
+    config: {
+      policies: [],
+    },
+  },
+  {
+    method: 'PUT',
+    path: '/settings/config/reaction-type',
+    handler: 'settingsController.updateReactionType',
     config: {
       policies: [],
     },

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -18,7 +18,7 @@ const routes = [
   {
     method: 'PUT',
     path: '/settings/config',
-    handler: 'settingsController.update',
+    handler: 'settingsController.updateConfig',
     config: {
       policies: [],
     },

--- a/server/src/services/admin.ts
+++ b/server/src/services/admin.ts
@@ -12,7 +12,7 @@ import { ReactionsPluginStoreConfig } from '../config';
 export default ({ strapi }: { strapi: Core.Strapi }) => ({
   async fetchConfig() {
     const commonService = getPluginService<IServiceCommon>('common');
-    const pluginStore = commonService.getPluginStore();
+    const pluginStore = await commonService.getPluginStore();
     const storedConfig: ReactionsPluginStoreConfig | undefined = await pluginStore?.get({
       key: "config",
     });
@@ -40,7 +40,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     body: Pick<ReactionsPluginStoreConfig, 'blockedAuthorProps'>,
   ): Promise<ReactionsPluginConfig> {
     const commonService = getPluginService<IServiceCommon>('common');
-    const pluginStore = commonService.getPluginStore();
+    const pluginStore = await commonService.getPluginStore();
     const storedConfig: ReactionsPluginStoreConfig | undefined = await pluginStore?.get({
       key: 'config',
     });

--- a/server/src/services/admin.ts
+++ b/server/src/services/admin.ts
@@ -56,8 +56,21 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     return this.fetchConfig();
   },
 
+  async createReactionType(
+    body: CTReactionType,
+  ): Promise<CTReactionType> {
+    return await strapi
+      .documents(getModelUid("reaction-type"))
+      .create({
+        data: body,
+      });
+  },
 
+  async updateReactionType(
+    body: CTReactionType,
+  ): Promise<CTReactionType> {
     const { documentId, ...rest } = body;
+
     return await strapi
       .documents(getModelUid("reaction-type"))
       .update({

--- a/server/src/services/admin.ts
+++ b/server/src/services/admin.ts
@@ -6,14 +6,19 @@ import { ReactionsPluginConfig, IServiceAdmin, IServiceCommon, CTReactionType, C
 import { buildRelatedId, getModelUid } from './utils/functions';
 import PluginError from '../utils/error';
 import { getPluginService } from '../utils/functions';
+import { CONFIG_PARAMS } from '../utils/constants';
+import { ReactionsPluginStoreConfig } from '../config';
 
 export default ({ strapi }: { strapi: Core.Strapi }) => ({
   async fetchConfig() {
-    const pluginStore = getPluginService<IServiceCommon>('common')
-      .getPluginStore();
-    const config: ReactionsPluginConfig | unknown = await pluginStore?.get({
+    const commonService = getPluginService<IServiceCommon>('common');
+    const pluginStore = commonService.getPluginStore();
+    const storedConfig: ReactionsPluginStoreConfig | undefined = await pluginStore?.get({
       key: "config",
     });
+
+    const blockedAuthorProps = storedConfig?.blockedAuthorProps
+      ?? commonService.getLocalConfig(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS, []);
 
     const types = await strapi
       .documents(getModelUid("reaction-type"))
@@ -22,23 +27,35 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       });
 
     return {
-      config: config || {},
+      config: {
+        ...(storedConfig || {}),
+        blockedAuthorProps,
+      },
       types,
     };
   },
 
   async updateConfig(
     this: IServiceAdmin,
-    body: CTReactionType,
-  ): Promise<CTReactionType> {
+    body: Pick<ReactionsPluginStoreConfig, 'blockedAuthorProps'>,
+  ): Promise<ReactionsPluginConfig> {
+    const commonService = getPluginService<IServiceCommon>('common');
+    const pluginStore = commonService.getPluginStore();
+    const storedConfig: ReactionsPluginStoreConfig | undefined = await pluginStore?.get({
+      key: 'config',
+    });
 
-    if (isNil(body.documentId)) {
-      return await strapi
-        .documents(getModelUid("reaction-type"))
-        .create({
-          data: body,
-        });
-    }
+    await pluginStore?.set({
+      key: 'config',
+      value: {
+        ...(storedConfig || {}),
+        blockedAuthorProps: body.blockedAuthorProps,
+      },
+    });
+
+    return this.fetchConfig();
+  },
+
 
     const { documentId, ...rest } = body;
     return await strapi

--- a/server/src/services/admin.ts
+++ b/server/src/services/admin.ts
@@ -2,7 +2,7 @@ import { Core, Data } from '@strapi/strapi';
 import { first, isArray, isEmpty, isNil, isString } from 'lodash';
 import slugify from 'slugify';
 
-import { ReactionsPluginConfig, IServiceAdmin, IServiceCommon, CTReactionType, CTReaction } from "../../../@types";
+import { ReactionsPluginConfig, IServiceAdmin, IServiceCommon, CTReactionType, CTReaction, EditableReactionsPluginConfig } from "../../../@types";
 import { buildRelatedId, getModelUid } from './utils/functions';
 import PluginError from '../utils/error';
 import { getPluginService } from '../utils/functions';
@@ -37,7 +37,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
 
   async updateConfig(
     this: IServiceAdmin,
-    body: Pick<ReactionsPluginStoreConfig, 'blockedAuthorProps'>,
+    body: EditableReactionsPluginConfig,
   ): Promise<ReactionsPluginConfig> {
     const commonService = getPluginService<IServiceCommon>('common');
     const pluginStore = await commonService.getPluginStore();

--- a/server/src/services/client.ts
+++ b/server/src/services/client.ts
@@ -22,9 +22,9 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
   },
 
   async sanitizeReactions(entities: Array<CTReaction>): Promise<Array<CTReaction>> {
-    const blockedAuthorProps = await this.getCommonService().getConfig(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS, []) as Array<string>;
+    const blockedAuthorProps = await this.getCommonService().getConfig(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS, []);
 
-    return entities.map((entity) => sanitizeReactionEntity(entity, blockedAuthorProps ?? []));
+    return entities.map((entity) => sanitizeReactionEntity(entity, blockedAuthorProps));
   },
 
   async kinds(
@@ -177,27 +177,26 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
 
     const result = !isArray(entities) ? [entities] : entities;
 
-    const enriched = await Promise.all(result.map(async (entity) => {
-      const { relatedUid, related } = entity;
-      if (query?.populate && isRelatedObjectPopulated(query.populate)) {
-        const [uid, documentId] = relatedUid.split(':');
-        const targetRelated = await strapi
-          .documents(uid)
-          .findOne({
+    return await Promise.all(
+      result.map(async (entity) => {
+        const { relatedUid, related } = entity;
+        if (query?.populate && isRelatedObjectPopulated(query.populate)) {
+          const [uid, documentId] = relatedUid.split(":");
+          const targetRelated = await strapi.documents(uid).findOne({
             documentId,
             locale: entity.locale,
           });
+          return {
+            ...entity,
+            related: targetRelated,
+          };
+        }
         return {
           ...entity,
-          related: targetRelated,
+          related: isArray(related) ? first(related) : related,
         };
-      }
-      return {
-        ...entity,
-        related: isArray(related) ? first(related) : related,
-      };
-    }));
-    return this.sanitizeReactions(enriched);
+      }),
+    ).then((enriched) => this.sanitizeReactions(enriched));
   },
 
   async create(

--- a/server/src/services/client.ts
+++ b/server/src/services/client.ts
@@ -2,8 +2,10 @@ import { Core, Data, UID } from '@strapi/strapi';
 import { isArray, isNil, first, isObject } from "lodash";
 import { AnyEntity, StrapiUser, StrapiQueryParamsParsed, StrapiRequestQueryPopulateClause, Primitive } from "@sensinum/strapi-utils";
 
-import { CTReaction, CTReactionType, IServiceClient } from "../../../@types";
-import { buildRelatedId, getModelUid } from './utils/functions';
+import { CTReaction, CTReactionType, IServiceClient, IServiceCommon } from "../../../@types";
+import { buildRelatedId, getModelUid, sanitizeReactionEntity } from './utils/functions';
+import { CONFIG_PARAMS } from '../utils/constants';
+import { getPluginService } from '../utils/functions';
 import PluginError from '../utils/error';
 
 export type PrefetchConditionsProps = {
@@ -14,6 +16,16 @@ export type PrefetchConditionsProps = {
 };
 
 export default ({ strapi }: { strapi: Core.Strapi }) => ({
+
+  getCommonService(): IServiceCommon {
+    return getPluginService<IServiceCommon>('common');
+  },
+
+  async sanitizeReactions(entities: Array<CTReaction>): Promise<Array<CTReaction>> {
+    const blockedAuthorProps = await this.getCommonService().getConfig(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS, []) as Array<string>;
+
+    return entities.map((entity) => sanitizeReactionEntity(entity, blockedAuthorProps ?? []));
+  },
 
   async kinds(
     this: IServiceClient,
@@ -100,7 +112,9 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       return [];
     }
 
-    return (!isArray(entities) ? [entities] : entities);
+    const result = !isArray(entities) ? [entities] : entities;
+
+    return this.sanitizeReactions(result);
   },
 
   async listPerUser(
@@ -163,7 +177,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
 
     const result = !isArray(entities) ? [entities] : entities;
 
-    return Promise.all(result.map(async (entity) => {
+    const enriched = await Promise.all(result.map(async (entity) => {
       const { relatedUid, related } = entity;
       if (query?.populate && isRelatedObjectPopulated(query.populate)) {
         const [uid, documentId] = relatedUid.split(':');
@@ -183,6 +197,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
         related: isArray(related) ? first(related) : related,
       };
     }));
+    return this.sanitizeReactions(enriched);
   },
 
   async create(

--- a/server/src/services/common.ts
+++ b/server/src/services/common.ts
@@ -4,9 +4,9 @@ import { ReactionsPluginStoreConfig } from '../config';
 import { CONFIG_PARAMS, PLUGIN_SELECTOR } from '../utils/constants';
 
 export default ({ strapi }: { strapi: Core.Strapi }) => ({
-  getPluginStore(): any | undefined {
+  async getPluginStore(): Promise<ReturnType<typeof strapi.store>> {
     if (!isNil(strapi.store)) {
-      return strapi.store({ type: "plugin", name: "reactions" }) as any;
+      return await strapi.store({ type: "plugin", name: "reactions" });
     }
   },
 
@@ -24,8 +24,8 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     prop?: K,
     defaultValue?: ReactionsPluginStoreConfig[K],
   ): Promise<ReactionsPluginStoreConfig | ReactionsPluginStoreConfig[K]> {
-    const pluginStore = this.getPluginStore();
-    const storedConfig = await pluginStore?.get({ key: 'config' }) as ReactionsPluginStoreConfig | undefined;
+    const pluginStore = await this.getPluginStore();
+    const storedConfig = await pluginStore.get({ key: 'config' }) as ReactionsPluginStoreConfig | undefined;
 
     if (storedConfig) {
       if (prop) {

--- a/server/src/services/common.ts
+++ b/server/src/services/common.ts
@@ -1,11 +1,46 @@
 import { Core } from '@strapi/strapi';
-
-import { isNil } from 'lodash';
+import { get, isNil } from 'lodash';
+import { ReactionsPluginStoreConfig } from '../config';
+import { CONFIG_PARAMS, PLUGIN_SELECTOR } from '../utils/constants';
 
 export default ({ strapi }: { strapi: Core.Strapi }) => ({
   getPluginStore(): any | undefined {
     if (!isNil(strapi.store)) {
       return strapi.store({ type: "plugin", name: "reactions" }) as any;
     }
+  },
+
+  getLocalConfig<K extends keyof ReactionsPluginStoreConfig>(
+    prop: K,
+    defaultValue?: ReactionsPluginStoreConfig[K],
+  ): ReactionsPluginStoreConfig[K] {
+    return strapi.config.get(
+      [PLUGIN_SELECTOR, prop].filter(Boolean).join('.'),
+      defaultValue,
+    );
+  },
+
+  async getConfig<K extends keyof ReactionsPluginStoreConfig>(
+    prop?: K,
+    defaultValue?: ReactionsPluginStoreConfig[K],
+  ): Promise<ReactionsPluginStoreConfig | ReactionsPluginStoreConfig[K]> {
+    const pluginStore = this.getPluginStore();
+    const storedConfig = await pluginStore?.get({ key: 'config' }) as ReactionsPluginStoreConfig | undefined;
+
+    if (storedConfig) {
+      if (prop) {
+        return get(storedConfig, prop, defaultValue) as ReactionsPluginStoreConfig[K];
+      }
+
+      return storedConfig;
+    }
+
+    if (prop) {
+      return this.getLocalConfig(prop, defaultValue);
+    }
+
+    return {
+      blockedAuthorProps: this.getLocalConfig(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS, []),
+    };
   },
 });

--- a/server/src/services/common.ts
+++ b/server/src/services/common.ts
@@ -1,7 +1,9 @@
-import { Core } from '@strapi/strapi';
-import { get, isNil } from 'lodash';
-import { ReactionsPluginStoreConfig } from '../config';
-import { CONFIG_PARAMS, PLUGIN_SELECTOR } from '../utils/constants';
+import { Core } from "@strapi/strapi";
+import { get, isNil } from "lodash";
+import { ReactionsPluginStoreConfig } from "../config";
+import config from "../config";
+import { PLUGIN_SELECTOR } from "../utils/constants";
+import PluginError from "../utils/error";
 
 export default ({ strapi }: { strapi: Core.Strapi }) => ({
   async getPluginStore(): Promise<ReturnType<typeof strapi.store>> {
@@ -11,13 +13,20 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
   },
 
   getLocalConfig<K extends keyof ReactionsPluginStoreConfig>(
-    prop: K,
+    prop?: K,
     defaultValue?: ReactionsPluginStoreConfig[K],
-  ): ReactionsPluginStoreConfig[K] {
-    return strapi.config.get(
-      [PLUGIN_SELECTOR, prop].filter(Boolean).join('.'),
-      defaultValue,
-    );
+  ): ReactionsPluginStoreConfig | ReactionsPluginStoreConfig[K] {
+    const localReactionsConfig = strapi.config.get(PLUGIN_SELECTOR, {});
+    const merged = {
+      ...config.default,
+      ...localReactionsConfig,
+    };
+
+    if (prop) {
+      return get(localReactionsConfig, prop, defaultValue ?? merged[prop]);
+    }
+
+    return merged;
   },
 
   async getConfig<K extends keyof ReactionsPluginStoreConfig>(
@@ -25,22 +34,24 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
     defaultValue?: ReactionsPluginStoreConfig[K],
   ): Promise<ReactionsPluginStoreConfig | ReactionsPluginStoreConfig[K]> {
     const pluginStore = await this.getPluginStore();
-    const storedConfig = await pluginStore.get({ key: 'config' }) as ReactionsPluginStoreConfig | undefined;
+    const storedConfig = await pluginStore.get({ key: "config" });
+    const rawConfig = storedConfig ?? this.getLocalConfig();
+    const validatedConfig = config.validate(rawConfig);
 
-    if (storedConfig) {
-      if (prop) {
-        return get(storedConfig, prop, defaultValue) as ReactionsPluginStoreConfig[K];
-      }
-
-      return storedConfig;
+    if (!validatedConfig.success) {
+      throw new PluginError(400, "Invalid plugin config");
     }
+
+    const validatedConfigData = validatedConfig.data;
 
     if (prop) {
-      return this.getLocalConfig(prop, defaultValue);
+      return get(
+        validatedConfigData,
+        prop,
+        defaultValue ?? config.default[prop],
+      );
     }
 
-    return {
-      blockedAuthorProps: this.getLocalConfig(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS, []),
-    };
+    return validatedConfigData;
   },
 });

--- a/server/src/services/enrich.ts
+++ b/server/src/services/enrich.ts
@@ -1,8 +1,10 @@
 import { Core, UID } from '@strapi/strapi';
 import { PopulateClause } from '@sensinum/strapi-utils';
 
-import { IServiceEnrich, ReactionEntity, RelatedId } from "../../../@types";
-import { buildRelatedId, getModelUid } from './utils/functions';
+import { IServiceEnrich, IServiceCommon, ReactionEntity, RelatedId } from "../../../@types";
+import { buildRelatedId, getModelUid, sanitizeReactionEntity } from './utils/functions';
+import { CONFIG_PARAMS } from '../utils/constants';
+import { getPluginService } from '../utils/functions';
 import { first } from 'lodash';
 
 export type StrapiReactions = Array<ReactionEntity>;
@@ -30,6 +32,16 @@ const DEFAULT_POPULATE = {
 
 export default ({ strapi }: { strapi: Core.Strapi }) => ({
 
+  getCommonService(): IServiceCommon {
+    return getPluginService<IServiceCommon>('common');
+  },
+
+  async sanitizeReactions(reactions: Array<ReactionEntity>): Promise<Array<ReactionEntity>> {
+    const blockedAuthorProps = await this.getCommonService().getConfig(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS, []) as Array<string>;
+
+    return reactions.map((reaction) => sanitizeReactionEntity(reaction, blockedAuthorProps ?? []));
+  },
+
   async enrichOne<T extends ReactionEntity, M extends any>(
     this: IServiceEnrich,
     uid: UID.ContentType,
@@ -47,11 +59,12 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       relatedUid: buildRelatedId(uid, data.documentId),
     }, populate, data?.locale);
 
+    const sanitizedReactions = await this.sanitizeReactions(reactions || []);
     return {
       ...response,
       meta: {
         ...response.meta,
-        reactions: (reactions || []).reduce(this.composeReactionsMeta, {}),
+        reactions: sanitizedReactions.reduce(this.composeReactionsMeta, {}),
       },
     };
   },
@@ -76,6 +89,8 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       }
     }, populate, firstEntity?.locale);
 
+    const sanitizedReactions = await this.sanitizeReactions(reactions || []);
+
     return {
       ...response,
       meta: {
@@ -83,7 +98,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
         reactions: response.data
           .reduce((accItem, currItem) => ({
             ...accItem,
-            [currItem.documentId]: (reactions || [])
+            [currItem.documentId]: sanitizedReactions
               .filter(({ relatedUid }: { relatedUid: RelatedId}) => relatedUid === buildRelatedId(uid, currItem.documentId))
               .reduce(this.composeReactionsMeta, {}),
           }), {}),

--- a/server/src/services/enrich.ts
+++ b/server/src/services/enrich.ts
@@ -37,9 +37,9 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
   },
 
   async sanitizeReactions(reactions: Array<ReactionEntity>): Promise<Array<ReactionEntity>> {
-    const blockedAuthorProps = await this.getCommonService().getConfig(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS, []) as Array<string>;
+    const blockedAuthorProps = await this.getCommonService().getConfig(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS, []);
 
-    return reactions.map((reaction) => sanitizeReactionEntity(reaction, blockedAuthorProps ?? []));
+    return reactions.map((reaction) => sanitizeReactionEntity(reaction, blockedAuthorProps));
   },
 
   async enrichOne<T extends ReactionEntity, M extends any>(
@@ -59,7 +59,8 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       relatedUid: buildRelatedId(uid, data.documentId),
     }, populate, data?.locale);
 
-    const sanitizedReactions = await this.sanitizeReactions(reactions || []);
+    const sanitizedReactions = reactions ? await this.sanitizeReactions(reactions) : [];
+    
     return {
       ...response,
       meta: {
@@ -89,7 +90,7 @@ export default ({ strapi }: { strapi: Core.Strapi }) => ({
       }
     }, populate, firstEntity?.locale);
 
-    const sanitizedReactions = await this.sanitizeReactions(reactions || []);
+    const sanitizedReactions = reactions ? await this.sanitizeReactions(reactions) : [];
 
     return {
       ...response,

--- a/server/src/services/utils/functions.ts
+++ b/server/src/services/utils/functions.ts
@@ -1,22 +1,33 @@
 import { UID, Data } from "@strapi/strapi";
 import { isEmpty } from 'lodash';
-
+import { z } from 'zod';
 import { CTReaction } from '../../../../@types';
 
+const userRecordSchema = z.record(z.string(), z.unknown());
+
 export const sanitizeReactionUser = (
-  user: Record<string, unknown> | null | undefined,
+  user: unknown,
   blockedUserProps: Array<string>,
 ) => {
-  if (!user || typeof user !== 'object') {
+  const parsedUser = userRecordSchema.safeParse(user);
+
+  if (!parsedUser.success) {
     return user;
   }
 
+  const parsedUserData = parsedUser.data;
+  
   const sanitizedUser = Object.fromEntries(
-    Object.entries(user)
+    Object.entries(parsedUserData)
       .filter(([name]) => !blockedUserProps.includes(name)),
   );
 
-  return isEmpty(sanitizedUser) ? user : sanitizedUser;
+  if (isEmpty(sanitizedUser)) {
+    strapi.log.warn('Strapi Reactions Plugin:You filtered out all of users properties, so the user is empty object');
+    return {}
+  } else {
+    return sanitizedUser;
+  }
 };
 
 export const sanitizeReactionEntity = (
@@ -29,7 +40,7 @@ export const sanitizeReactionEntity = (
 
   return {
     ...entity,
-    user: sanitizeReactionUser(entity.user as Record<string, unknown>, blockedUserProps),
+    user: sanitizeReactionUser(entity.user, blockedUserProps),
   };
 };
 

--- a/server/src/services/utils/functions.ts
+++ b/server/src/services/utils/functions.ts
@@ -1,4 +1,37 @@
 import { UID, Data } from "@strapi/strapi";
+import { isEmpty } from 'lodash';
+
+import { CTReaction } from '../../../../@types';
+
+export const sanitizeReactionUser = (
+  user: Record<string, unknown> | null | undefined,
+  blockedUserProps: Array<string>,
+) => {
+  if (!user || typeof user !== 'object') {
+    return user;
+  }
+
+  const sanitizedUser = Object.fromEntries(
+    Object.entries(user)
+      .filter(([name]) => !blockedUserProps.includes(name)),
+  );
+
+  return isEmpty(sanitizedUser) ? user : sanitizedUser;
+};
+
+export const sanitizeReactionEntity = (
+  entity: CTReaction,
+  blockedUserProps: Array<string>,
+): CTReaction => {
+  if (!entity.user || typeof entity.user !== 'object') {
+    return entity;
+  }
+
+  return {
+    ...entity,
+    user: sanitizeReactionUser(entity.user as Record<string, unknown>, blockedUserProps),
+  };
+};
 
 export const getModelUid = (name: string): UID.ContentType => {
   const contentType = strapi.plugin("reactions").contentTypes[name];

--- a/server/src/utils/constants.ts
+++ b/server/src/utils/constants.ts
@@ -1,0 +1,5 @@
+export const CONFIG_PARAMS = {
+  AUTHOR_BLOCKED_PROPS: 'blockedAuthorProps',
+} as const;
+
+export const PLUGIN_SELECTOR = 'plugin.reactions';

--- a/server/src/utils/functions.ts
+++ b/server/src/utils/functions.ts
@@ -2,7 +2,7 @@ import { Primitive } from "../../../@types";
 import PluginError from "./error";
 
 export const getPluginService = <T>(name: string): T =>
-  strapi.plugin("reactions").service(name);
+  strapi.plugin("reactions").service(name) as T;
 
 export const parseParams = <T = Record<string, unknown>>(
   params: Record<string, unknown>

--- a/server/tests/initSetup.ts
+++ b/server/tests/initSetup.ts
@@ -1,4 +1,4 @@
-import { get, set, pick, isEmpty, isObject, isArray } from "lodash";
+import { get, set, pick, isEmpty } from "lodash";
 
 const mockStrapi = (config: any = {}, toStore: boolean = false, database: any = {}, documents: any = {}) => {
   const dbConfig = toStore
@@ -49,6 +49,8 @@ const mockStrapi = (config: any = {}, toStore: boolean = false, database: any = 
             new Promise((resolve) => resolve(value)),
           delete: async (value: any) =>
             new Promise((resolve) => resolve(value)),
+          deleteMany: async (value: any) =>
+            new Promise((resolve) => resolve(value)),
         };
       },
       ...dbConfig,
@@ -82,9 +84,22 @@ const mockStrapi = (config: any = {}, toStore: boolean = false, database: any = 
           const index = documentsData[uid]?.findIndex((r: any) => r.documentId === documentId || r.id === documentId);
           if (index !== undefined && index >= 0 && documentsData[uid]) {
             documentsData[uid].splice(index, 1);
-            return new Promise((resolve) => resolve(true));
+            return new Promise((resolve) => resolve({ documentId }));
           }
           return new Promise((resolve) => resolve(false));
+        }),
+        update: jest.fn(async (args: any = {}) => {
+          const { documentId, data } = args;
+          const index = documentsData[uid]?.findIndex((r: any) => r.documentId === documentId || r.id === documentId);
+          if (index !== undefined && index >= 0 && documentsData[uid]) {
+            documentsData[uid][index] = {
+              ...documentsData[uid][index],
+              ...data,
+              documentId,
+            };
+            return new Promise((resolve) => resolve(documentsData[uid][index]));
+          }
+          return new Promise((resolve) => resolve(null));
         }),
       };
     }),
@@ -133,6 +148,7 @@ const mockStrapi = (config: any = {}, toStore: boolean = false, database: any = 
           enrich: require("../src/services/enrich"),
           client: require("../src/services/client"),
           admin: require("../src/services/admin"),
+          common: require("../src/services/common"),
         },
         contentTypes: {
           reaction: {
@@ -155,8 +171,8 @@ const mockStrapi = (config: any = {}, toStore: boolean = false, database: any = 
       },
     },
     config: {
-      get: function (prop: string = "") {
-        return get(this.plugins, prop.replace("plugin.", ""));
+      get: function (prop: string = "", defaultValue?: unknown) {
+        return get(this.plugins, prop.replace("plugin.", ""), defaultValue);
       },
       set: function (prop: string = "", value: any) {
         return set(this.plugins, prop.replace("plugin.", ""), value);

--- a/server/tests/services/admin.test.ts
+++ b/server/tests/services/admin.test.ts
@@ -104,6 +104,16 @@ describe("Test admin service", () => {
         slug: "like",
       }));
     });
+
+    it("should return null when reaction type does not exist", async () => {
+      const documents = global.strapi.documents("plugins::reactions.reaction-type" as any);
+      const result = await documents.update({
+        documentId: "missing-type",
+        data: { name: "Missing" },
+      } as any);
+
+      expect(result).toBeNull();
+    });
   });
 
   describe("updateConfig", () => {

--- a/server/tests/services/admin.test.ts
+++ b/server/tests/services/admin.test.ts
@@ -1,0 +1,135 @@
+import { setupStrapi, resetStrapi } from "../initSetup";
+import { getPluginService } from "../../src/utils/functions";
+import { IServiceAdmin } from "../../../@types";
+import PluginError from "../../src/utils/error";
+
+describe("Test admin service", () => {
+  const mockReactionTypes = [
+    {
+      documentId: "type-1",
+      slug: "like",
+      name: "Like",
+      icon: { id: 1, url: "/icon.png" },
+    },
+    {
+      documentId: "type-2",
+      slug: "love",
+      name: "Love",
+      icon: null,
+    },
+  ];
+
+  const mockReactions = [
+    {
+      documentId: "reaction-1",
+      kind: mockReactionTypes[0],
+      relatedUid: "api::article.article:1",
+    },
+  ];
+
+  beforeEach(() => {
+    setupStrapi({}, false, {}, {
+      "plugins::reactions.reaction-type": [...mockReactionTypes],
+      "plugins::reactions.reaction": [...mockReactions],
+    });
+  });
+
+  afterEach(() => {
+    resetStrapi();
+  });
+
+  describe("fetchConfig", () => {
+    it("should return plugin config with reaction types", async () => {
+      const service = getPluginService<IServiceAdmin>("admin");
+      const result = await service.fetchConfig();
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction-type");
+      expect(result).toEqual({
+        config: {
+          blockedAuthorProps: [],
+        },
+        types: mockReactionTypes,
+      });
+    });
+  });
+
+  describe("createReactionType", () => {
+    it("should create a reaction type", async () => {
+      const service = getPluginService<IServiceAdmin>("admin");
+      const payload = {
+        name: "Wow",
+        slug: "wow",
+      };
+
+      const result = await service.createReactionType(payload as any);
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction-type");
+
+      const documentsInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[
+        (global.strapi.documents as unknown as jest.Mock).mock.results.length - 1
+      ].value;
+      expect(documentsInstance.create).toHaveBeenCalledWith({
+        data: payload,
+      });
+      expect(result).toEqual(expect.objectContaining(payload));
+    });
+  });
+
+  describe("updateReactionType", () => {
+    it("should update a reaction type", async () => {
+      const service = getPluginService<IServiceAdmin>("admin");
+      const payload = {
+        documentId: "type-1",
+        name: "Like updated",
+        slug: "like",
+      };
+
+      const result = await service.updateReactionType(payload as any);
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction-type");
+
+      const documentsInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[
+        (global.strapi.documents as unknown as jest.Mock).mock.results.length - 1
+      ].value;
+      expect(documentsInstance.update).toHaveBeenCalledWith({
+        documentId: "type-1",
+        data: {
+          name: "Like updated",
+          slug: "like",
+        },
+      });
+      expect(result).toEqual(expect.objectContaining({
+        documentId: "type-1",
+        name: "Like updated",
+        slug: "like",
+      }));
+    });
+  });
+
+  describe("updateConfig", () => {
+    it("should update general plugin config", async () => {
+      const service = getPluginService<IServiceAdmin>("admin");
+      const blockedAuthorProps = ["email", "username"];
+
+      const result = await service.updateConfig({ blockedAuthorProps });
+
+      expect(result.config.blockedAuthorProps).toEqual(blockedAuthorProps);
+      expect(result.types).toEqual(mockReactionTypes);
+    });
+  });
+
+  describe("deleteReactionType", () => {
+    it("should delete reaction type and related reactions", async () => {
+      const service = getPluginService<IServiceAdmin>("admin");
+      const result = await service.deleteReactionType("type-1");
+
+      expect(result).toEqual({ result: true });
+    });
+
+    it("should throw when reaction type does not exist", async () => {
+      const service = getPluginService<IServiceAdmin>("admin");
+
+      await expect(service.deleteReactionType("missing-type")).rejects.toBeInstanceOf(PluginError);
+    });
+  });
+});

--- a/server/tests/services/common.test.ts
+++ b/server/tests/services/common.test.ts
@@ -1,0 +1,67 @@
+import { setupStrapi, resetStrapi } from '../initSetup';
+import { getPluginService } from '../../src/utils/functions';
+import { IServiceCommon } from '../../../@types';
+import { CONFIG_PARAMS } from '../../src/utils/constants';
+
+afterEach(() => {
+  resetStrapi();
+});
+
+describe('common service', () => {
+  describe('getPluginStore', () => {
+    it('returns plugin store when strapi.store is available', async () => {
+      setupStrapi();
+      const service = getPluginService<IServiceCommon>('common');
+      const store = await service.getPluginStore();
+
+      expect(store).toHaveProperty('get');
+      expect(store).toHaveProperty('set');
+    });
+  });
+
+  describe('getLocalConfig', () => {
+    it('reads config from strapi config', () => {
+      setupStrapi({ blockedAuthorProps: ['email'] });
+      const service = getPluginService<IServiceCommon>('common');
+
+      expect(service.getLocalConfig(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS, [])).toEqual(['email']);
+    });
+
+    it('returns default when property is missing', () => {
+      setupStrapi({});
+      const service = getPluginService<IServiceCommon>('common');
+
+      expect(service.getLocalConfig(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS, ['fallback'])).toEqual(['fallback']);
+    });
+  });
+
+  describe('getConfig', () => {
+    it('returns full stored config when no prop is given', async () => {
+      setupStrapi({ blockedAuthorProps: ['email'] }, true);
+      const service = getPluginService<IServiceCommon>('common');
+
+      await expect(service.getConfig()).resolves.toEqual({ blockedAuthorProps: ['email'] });
+    });
+
+    it('returns default config from local settings when store is empty', async () => {
+      setupStrapi({ blockedAuthorProps: ['username'] });
+      const service = getPluginService<IServiceCommon>('common');
+
+      await expect(service.getConfig()).resolves.toEqual({ blockedAuthorProps: ['username'] });
+    });
+
+    it('returns a single property from stored config', async () => {
+      setupStrapi({ blockedAuthorProps: ['stored'] }, true);
+      const service = getPluginService<IServiceCommon>('common');
+
+      await expect(service.getConfig(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS)).resolves.toEqual(['stored']);
+    });
+
+    it('returns a single property from local config when store is empty', async () => {
+      setupStrapi({ blockedAuthorProps: ['local'] });
+      const service = getPluginService<IServiceCommon>('common');
+
+      await expect(service.getConfig(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS)).resolves.toEqual(['local']);
+    });
+  });
+});

--- a/server/tests/services/enrich.test.ts
+++ b/server/tests/services/enrich.test.ts
@@ -1,0 +1,273 @@
+import { setupStrapi, resetStrapi } from "../initSetup";
+import { getPluginService } from "../../src/utils/functions";
+import { IServiceEnrich } from "../../../@types";
+
+describe("Test enrich service", () => {
+  const uid = "api::article.article";
+
+  const mockUser = {
+    documentId: "user-1",
+    username: "testuser",
+    email: "test@example.com",
+  };
+
+  const mockReactionTypes = {
+    like: {
+      documentId: "type-1",
+      slug: "like",
+      name: "Like",
+      emoji: "👍",
+    },
+    love: {
+      documentId: "type-2",
+      slug: "love",
+      name: "Love",
+      emoji: "❤️",
+    },
+  };
+
+  const createReaction = (overrides: Record<string, unknown> = {}) => ({
+    documentId: "reaction-1",
+    kind: mockReactionTypes.like,
+    user: mockUser,
+    relatedUid: "api::article.article:doc-1",
+    ...overrides,
+  });
+
+  const defaultPopulate = {
+    kind: {
+      fields: ["name", "slug", "emoji", "emojiFallbackUrl"],
+      populate: ["icon"],
+    },
+    user: {
+      fields: ["username", "email"],
+    },
+  };
+
+  afterEach(() => {
+    resetStrapi();
+  });
+
+  describe("sanitizeReactions", () => {
+    it("should strip blocked author properties from reaction users", async () => {
+      setupStrapi({ blockedAuthorProps: ["email"] }, false, {}, {});
+
+      const service = getPluginService<IServiceEnrich>("enrich");
+      const result = await service.sanitizeReactions([createReaction()]);
+
+      expect(result[0].user).toEqual({
+        documentId: "user-1",
+        username: "testuser",
+      });
+    });
+
+    it("should read blockedAuthorProps from plugin store", async () => {
+      setupStrapi({ blockedAuthorProps: ["email", "username"] }, true, {}, {});
+
+      const service = getPluginService<IServiceEnrich>("enrich");
+      const result = await service.sanitizeReactions([createReaction()]);
+
+      expect(result[0].user).toEqual({
+        documentId: "user-1",
+      });
+    });
+
+    it("should return reactions unchanged when blockedAuthorProps is empty", async () => {
+      setupStrapi({}, false, {}, {});
+
+      const service = getPluginService<IServiceEnrich>("enrich");
+      const reactions = [createReaction()];
+      const result = await service.sanitizeReactions(reactions);
+
+      expect(result).toEqual(reactions);
+    });
+  });
+
+  describe("composeReactionsMeta", () => {
+    it("should group reactions by kind slug", () => {
+      setupStrapi({}, false, {}, {});
+
+      const service = getPluginService<IServiceEnrich>("enrich");
+      const reactions = [
+        createReaction({ documentId: "reaction-1" }),
+        createReaction({
+          documentId: "reaction-2",
+          kind: mockReactionTypes.love,
+        }),
+        createReaction({ documentId: "reaction-3" }),
+      ];
+
+      const result = reactions.reduce(service.composeReactionsMeta, {});
+
+      expect(result).toEqual({
+        like: [reactions[0], reactions[2]],
+        love: [reactions[1]],
+      });
+    });
+  });
+
+  describe("enrichOne", () => {
+    it("should return response unchanged when response is falsy", async () => {
+      setupStrapi({}, false, {}, {});
+
+      const service = getPluginService<IServiceEnrich>("enrich");
+
+      await expect(service.enrichOne(uid, null as any, undefined as any)).resolves.toBeNull();
+      await expect(service.enrichOne(uid, undefined as any, undefined as any)).resolves.toBeUndefined();
+    });
+
+    it("should enrich response meta with sanitized reactions grouped by slug", async () => {
+      const reactions = [
+        createReaction({ documentId: "reaction-1" }),
+        createReaction({
+          documentId: "reaction-2",
+          kind: mockReactionTypes.love,
+        }),
+      ];
+
+      setupStrapi({ blockedAuthorProps: ["email"] }, false, {}, {
+        "plugins::reactions.reaction": reactions,
+      });
+
+      const service = getPluginService<IServiceEnrich>("enrich");
+      const response = {
+        data: { documentId: "doc-1", title: "Test Article", locale: "en" },
+        meta: { pagination: { page: 1 } },
+      };
+
+      const result = await service.enrichOne(uid, response, undefined as any);
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction");
+
+      const documentsInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[0].value;
+      expect(documentsInstance.findMany).toHaveBeenCalledWith({
+        filters: {
+          relatedUid: "api::article.article:doc-1",
+        },
+        populate: defaultPopulate,
+        locale: "en",
+      });
+
+      expect(result.data).toEqual(response.data);
+      expect(result.meta).toEqual({
+        pagination: { page: 1 },
+        reactions: {
+          like: [
+            expect.objectContaining({
+              documentId: "reaction-1",
+              user: {
+                documentId: "user-1",
+                username: "testuser",
+              },
+            }),
+          ],
+          love: [
+            expect.objectContaining({
+              documentId: "reaction-2",
+              user: {
+                documentId: "user-1",
+                username: "testuser",
+              },
+            }),
+          ],
+        },
+      });
+    });
+
+    it("should return empty reactions meta when no reactions are found", async () => {
+      setupStrapi({}, false, {}, {
+        "plugins::reactions.reaction": [],
+      });
+
+      const service = getPluginService<IServiceEnrich>("enrich");
+      const response = {
+        data: { documentId: "doc-1", locale: "en" },
+        meta: {},
+      };
+
+      const result = await service.enrichOne(uid, response, undefined as any);
+
+      expect((result.meta as any).reactions).toEqual({});
+    });
+  });
+
+  describe("enrichMany", () => {
+    it("should return response unchanged when response is falsy", async () => {
+      setupStrapi({}, false, {}, {});
+
+      const service = getPluginService<IServiceEnrich>("enrich");
+
+      await expect(service.enrichMany(uid, null as any, undefined as any)).resolves.toBeNull();
+      await expect(service.enrichMany(uid, undefined as any, undefined as any)).resolves.toBeUndefined();
+    });
+
+    it("should map sanitized reactions per documentId", async () => {
+      const reactions = [
+        createReaction({
+          documentId: "reaction-1",
+          relatedUid: "api::article.article:doc-1",
+        }),
+        createReaction({
+          documentId: "reaction-2",
+          kind: mockReactionTypes.love,
+          relatedUid: "api::article.article:doc-2",
+        }),
+      ];
+
+      setupStrapi({ blockedAuthorProps: ["email", "username"] }, false, {}, {
+        "plugins::reactions.reaction": reactions,
+      });
+
+      const service = getPluginService<IServiceEnrich>("enrich");
+      const response = {
+        data: [
+          { documentId: "doc-1", locale: "en" },
+          { documentId: "doc-2", locale: "en" },
+        ],
+        meta: { pagination: { page: 1 } },
+      };
+
+      const result = await service.enrichMany(uid, response, undefined as any);
+
+      expect(global.strapi.documents).toHaveBeenCalledWith("plugins::reactions.reaction");
+
+      const documentsInstance = (global.strapi.documents as unknown as jest.Mock).mock.results[0].value;
+      expect(documentsInstance.findMany).toHaveBeenCalledWith({
+        filters: {
+          relatedUid: {
+            $contains: "api::article.article:",
+          },
+        },
+        populate: defaultPopulate,
+        locale: "en",
+      });
+
+      expect(result.data).toEqual(response.data);
+      expect(result.meta).toEqual({
+        pagination: { page: 1 },
+        reactions: {
+          "doc-1": {
+            like: [
+              expect.objectContaining({
+                documentId: "reaction-1",
+                user: {
+                  documentId: "user-1",
+                },
+              }),
+            ],
+          },
+          "doc-2": {
+            love: [
+              expect.objectContaining({
+                documentId: "reaction-2",
+                user: {
+                  documentId: "user-1",
+                },
+              }),
+            ],
+          },
+        },
+      });
+    });
+  });
+});

--- a/server/tests/services/utils/functions.test.ts
+++ b/server/tests/services/utils/functions.test.ts
@@ -1,5 +1,16 @@
 import { sanitizeReactionEntity, sanitizeReactionUser } from '../../../src/services/utils/functions';
 
+beforeEach(() => {
+  Object.defineProperty(global, 'strapi', {
+    value: {
+      log: {
+        warn: jest.fn(),
+      },
+    },
+    writable: true,
+  });
+});
+
 describe('sanitizeReactionUser', () => {
   it('filters blocked user properties', () => {
     expect(
@@ -31,10 +42,16 @@ describe('sanitizeReactionUser', () => {
     expect(sanitizeReactionUser(undefined, ['email'])).toBeUndefined();
   });
 
-  it('returns original user when every property is blocked', () => {
-    const user = { email: 'joe@example.com' };
+  it('returns empty object when all user fields are filtered out', () => {
+    const user = {
+      email: 'joe@example.com',
+      username: 'joe',
+    };
 
-    expect(sanitizeReactionUser(user, ['email'])).toBe(user);
+    expect(sanitizeReactionUser(user, ['email', 'username'])).toEqual({});
+    expect(strapi.log.warn).toHaveBeenCalledWith(
+      'Strapi Reactions Plugin:You filtered out all of users properties, so the user is empty object',
+    );
   });
 });
 
@@ -84,5 +101,23 @@ describe('sanitizeReactionEntity', () => {
     } as any;
 
     expect(sanitizeReactionEntity(entity, ['email'])).toEqual(entity);
+  });
+
+  it('returns entity with empty user when all user fields are filtered out', () => {
+    const entity = {
+      documentId: 'reaction-1',
+      user: {
+        email: 'joe@example.com',
+        username: 'joe',
+      },
+    } as any;
+
+    expect(sanitizeReactionEntity(entity, ['email', 'username'])).toEqual({
+      documentId: 'reaction-1',
+      user: {},
+    });
+    expect(strapi.log.warn).toHaveBeenCalledWith(
+      'Strapi Reactions Plugin:You filtered out all of users properties, so the user is empty object',
+    );
   });
 });

--- a/server/tests/services/utils/functions.test.ts
+++ b/server/tests/services/utils/functions.test.ts
@@ -25,6 +25,17 @@ describe('sanitizeReactionUser', () => {
 
     expect(sanitizeReactionUser(user, [])).toEqual(user);
   });
+
+  it('returns nullish and non-object users unchanged', () => {
+    expect(sanitizeReactionUser(null, ['email'])).toBeNull();
+    expect(sanitizeReactionUser(undefined, ['email'])).toBeUndefined();
+  });
+
+  it('returns original user when every property is blocked', () => {
+    const user = { email: 'joe@example.com' };
+
+    expect(sanitizeReactionUser(user, ['email'])).toBe(user);
+  });
 });
 
 describe('sanitizeReactionEntity', () => {
@@ -64,5 +75,14 @@ describe('sanitizeReactionEntity', () => {
       userId: 'anonymous-123',
       user: null,
     });
+  });
+
+  it('preserves entity when user is not an object', () => {
+    const entity = {
+      documentId: 'reaction-1',
+      user: 'legacy-user-id',
+    } as any;
+
+    expect(sanitizeReactionEntity(entity, ['email'])).toEqual(entity);
   });
 });

--- a/server/tests/services/utils/functions.test.ts
+++ b/server/tests/services/utils/functions.test.ts
@@ -1,0 +1,68 @@
+import { sanitizeReactionEntity, sanitizeReactionUser } from '../../../src/services/utils/functions';
+
+describe('sanitizeReactionUser', () => {
+  it('filters blocked user properties', () => {
+    expect(
+      sanitizeReactionUser(
+        {
+          documentId: 'abc',
+          username: 'joe',
+          email: 'joe@example.com',
+        },
+        ['email'],
+      ),
+    ).toEqual({
+      documentId: 'abc',
+      username: 'joe',
+    });
+  });
+
+  it('returns user unchanged when no properties are blocked', () => {
+    const user = {
+      documentId: 'abc',
+      username: 'joe',
+    };
+
+    expect(sanitizeReactionUser(user, [])).toEqual(user);
+  });
+});
+
+describe('sanitizeReactionEntity', () => {
+  it('sanitizes nested user object', () => {
+    expect(
+      sanitizeReactionEntity(
+        {
+          documentId: 'reaction-1',
+          user: {
+            documentId: 'user-1',
+            username: 'joe',
+            email: 'joe@example.com',
+          },
+        } as any,
+        ['email', 'username'],
+      ),
+    ).toEqual({
+      documentId: 'reaction-1',
+      user: {
+        documentId: 'user-1',
+      },
+    });
+  });
+
+  it('preserves userId for anonymous reactions', () => {
+    expect(
+      sanitizeReactionEntity(
+        {
+          documentId: 'reaction-1',
+          userId: 'anonymous-123',
+          user: null,
+        } as any,
+        ['email'],
+      ),
+    ).toEqual({
+      documentId: 'reaction-1',
+      userId: 'anonymous-123',
+      user: null,
+    });
+  });
+});


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-reactions/issues/12

## Summary

What does this PR do/solve?

> Adds a blockAuthorProps property that allows you to manually block private data (such as email address or username) from being returned for reactions, which works similarly to the Comments plugin.
> Changes the nomenclature for setting/updating config

## Test Plan

Go to settings page for Reactions plugin and put in newly added section of "additional settings" value like email or username. Then check if it was sanitized from response.
